### PR TITLE
[columnar] fixes types larger than 8 bytes

### DIFF
--- a/columnar/src/test/regress/expected/columnar_alter_set_type.out
+++ b/columnar/src/test/regress/expected/columnar_alter_set_type.out
@@ -63,7 +63,7 @@ SELECT columnar.alter_columnar_table_set('test', compression => 'lz4');
 INSERT INTO test VALUES(1);
 VACUUM VERBOSE test;
 INFO:  statistics for "test":
-storage id: 10000000135
+storage id: 10000000136
 total file size: 24576, total data size: 6
 compression rate: 0.83x
 total row count: 1, stripe count: 1, average rows per stripe: 1
@@ -72,7 +72,7 @@ chunk count: 1, containing data for dropped columns: 0, lz4 compressed: 1
 ALTER TABLE test ALTER COLUMN i TYPE int8;
 VACUUM VERBOSE test;
 INFO:  statistics for "test":
-storage id: 10000000136
+storage id: 10000000137
 total file size: 24576, total data size: 10
 compression rate: 0.90x
 total row count: 1, stripe count: 1, average rows per stripe: 1

--- a/columnar/src/test/regress/expected/columnar_query.out
+++ b/columnar/src/test/regress/expected/columnar_query.out
@@ -278,3 +278,35 @@ SELECT * FROM t WHERE a = 1 ORDER BY b LIMIT 1;
 (1 row)
 
 DROP TABLE t;
+--
+-- [columnar] WHERE on INTEGER column not working when SELECT includes certain custom types
+--
+CREATE TABLE t(a INT, b point, c TEXT) USING columnar;
+INSERT INTO t SELECT g, point(1, g), 'abc_' || g FROM generate_series(0,100) AS g;
+EXPLAIN (analyze off, costs off, timing off, summary off)
+SELECT * FROM t WHERE a >= 90;
+                QUERY PLAN                 
+-------------------------------------------
+ Custom Scan (ColumnarScan) on t
+   Columnar Projected Columns: a, b, c
+   Columnar Chunk Group Filters: (a >= 90)
+   Columnar Vectorized Filter: (a >= 90)
+(4 rows)
+
+SELECT * FROM t WHERE a >= 90;
+  a  |    b    |    c    
+-----+---------+---------
+  90 | (1,90)  | abc_90
+  91 | (1,91)  | abc_91
+  92 | (1,92)  | abc_92
+  93 | (1,93)  | abc_93
+  94 | (1,94)  | abc_94
+  95 | (1,95)  | abc_95
+  96 | (1,96)  | abc_96
+  97 | (1,97)  | abc_97
+  98 | (1,98)  | abc_98
+  99 | (1,99)  | abc_99
+ 100 | (1,100) | abc_100
+(11 rows)
+
+DROP TABLE t;

--- a/columnar/src/test/regress/sql/columnar_query.sql
+++ b/columnar/src/test/regress/sql/columnar_query.sql
@@ -144,3 +144,19 @@ SELECT * FROM t WHERE a = 1 ORDER BY b LIMIT 1;
 SELECT * FROM t WHERE a = 1 ORDER BY b LIMIT 1;
 
 DROP TABLE t;
+
+
+--
+-- [columnar] WHERE on INTEGER column not working when SELECT includes certain custom types
+--
+
+CREATE TABLE t(a INT, b point, c TEXT) USING columnar;
+
+INSERT INTO t SELECT g, point(1, g), 'abc_' || g FROM generate_series(0,100) AS g;
+
+EXPLAIN (analyze off, costs off, timing off, summary off)
+SELECT * FROM t WHERE a >= 90;
+
+SELECT * FROM t WHERE a >= 90;
+
+DROP TABLE t;


### PR DESCRIPTION
Fixes #46. Handling now types which have `len` larger that 8 byte by directly copying value.