### PR TITLE
[columnar] Columnar vacuum

### DIFF
--- a/columnar/src/backend/columnar/columnar_customscan.c
+++ b/columnar/src/backend/columnar/columnar_customscan.c
@@ -1532,7 +1532,7 @@ static Cost
 ColumnarPerStripeScanCost(RelOptInfo *rel, Oid relationId, int numberOfColumnsRead)
 {
 	Relation relation = RelationIdGetRelation(relationId);
-	List *stripeList = StripesForRelfilenode(relation->rd_node);
+	List *stripeList = StripesForRelfilenode(relation->rd_node, ForwardScanDirection);
 	RelationClose(relation);
 
 	uint32 maxColumnCount = 0;
@@ -1584,7 +1584,7 @@ static uint64
 ColumnarTableStripeCount(Oid relationId)
 {
 	Relation relation = RelationIdGetRelation(relationId);
-	List *stripeList = StripesForRelfilenode(relation->rd_node);
+	List *stripeList = StripesForRelfilenode(relation->rd_node, ForwardScanDirection);
 	int stripeCount = list_length(stripeList);
 	RelationClose(relation);
 

--- a/columnar/src/backend/columnar/columnar_tableam.c
+++ b/columnar/src/backend/columnar/columnar_tableam.c
@@ -139,6 +139,7 @@ static bool ConditionalLockRelationWithTimeout(Relation rel, LOCKMODE lockMode,
 static List * NeededColumnsList(TupleDesc tupdesc, Bitmapset *attr_needed);
 static void LogRelationStats(Relation rel, int elevel);
 static void TruncateColumnar(Relation rel, int elevel);
+static bool TruncateAndCombineColumnarStripes(Relation rel, int elevel);
 static HeapTuple ColumnarSlotCopyHeapTuple(TupleTableSlot *slot);
 static void ColumnarCheckLogicalReplication(Relation rel);
 static Datum * detoast_values(TupleDesc tupleDesc, Datum *orig_values, bool *isnull);
@@ -1109,6 +1110,149 @@ NeededColumnsList(TupleDesc tupdesc, Bitmapset *attr_needed)
 	return columnList;
 }
 
+/*
+ * TruncateAndCombineColumnarStripes will combine last n stripes so they can fit
+ * maximum number of rows per stripe. Stripes that are going to be combined are deleted
+ * and new stripe will be written at the end of untouched last stripe. We also include
+ * information about deleted rows for this implementation.
+ */
+static bool
+TruncateAndCombineColumnarStripes(Relation rel, int elevel)
+{
+	uint64 totalRowNumberCount = 0;
+	uint32 startingStripeListPosition = 0;
+
+	TupleDesc tupleDesc = RelationGetDescr(rel);
+
+	if (tupleDesc->natts == 0)
+	{
+		ereport(elevel,
+				(errmsg("\"%s\": stopping vacuum due to zero column table",
+						RelationGetRelationName(rel))));
+		return false;
+	}
+
+	/* Get current columnar options */
+	ColumnarOptions columnarOptions = { 0 };
+	ReadColumnarOptions(rel->rd_id, &columnarOptions);
+
+	/* Get all stripes in reverse order */
+	List *stripeMetadataList = StripesForRelfilenode(rel->rd_node, BackwardScanDirection);
+	
+	/* Empty table nothing to do */
+	if (stripeMetadataList == NIL)
+	{
+		ereport(elevel,
+				(errmsg("\"%s\": stopping vacuum due to empty table",
+						RelationGetRelationName(rel))));
+		return false;
+	}
+
+	ListCell *lc = NULL;
+
+	uint32 lastStripeDeletedRows = 0;
+
+	foreach(lc, stripeMetadataList)
+	{
+		StripeMetadata * stripeMetadata = lfirst(lc);
+
+		lastStripeDeletedRows = DeletedRowsForStripe(rel->rd_node,
+													 stripeMetadata->chunkCount,
+													 stripeMetadata->id);
+
+		
+		uint64 stripeRowCount = stripeMetadata->rowCount - lastStripeDeletedRows;
+
+		if ((totalRowNumberCount + stripeRowCount > columnarOptions.stripeRowCount))
+		{
+			break;
+		}
+
+		totalRowNumberCount += stripeRowCount;
+		startingStripeListPosition++;
+	}
+
+	/* 
+	 * There is only one stripe that is candidate. Maybe we should vacuum
+	 * it if condition is met.
+	 */
+	if (startingStripeListPosition == 1)
+	{
+		/* Maybe we should vacuum only one stripe if count of
+		 * deleted rows is higher than 20 percent.
+		 */
+		float percentageOfDeleteRows = 
+			(float)lastStripeDeletedRows / (float)(totalRowNumberCount + lastStripeDeletedRows);
+
+		bool shouldVacuumOnlyStripe = percentageOfDeleteRows > 0.2f;
+
+		if (!shouldVacuumOnlyStripe)
+		{
+			return false;
+		}
+	}
+
+	ColumnarWriteState *writeState = ColumnarBeginWrite(rel->rd_node,
+														columnarOptions,
+														tupleDesc);
+
+	/* we need all columns */
+	int natts = rel->rd_att->natts;
+	Bitmapset *attr_needed = bms_add_range(NULL, 0, natts - 1);
+
+	/* no quals for table rewrite */
+	List *scanQual = NIL;
+
+	/* use SnapshotAny when re-writing table as heapAM does */
+	Snapshot snapshot = SnapshotAny;
+
+	MemoryContext scanContext = CreateColumnarScanMemoryContext();
+	bool randomAccess = true;
+	ColumnarReadState *readState = init_columnar_read_state(rel, tupleDesc,
+															attr_needed, scanQual,
+															scanContext, snapshot,
+															randomAccess,
+															NULL);
+
+	ColumnaSetStripeReadState(readState,
+							  list_nth(stripeMetadataList, startingStripeListPosition - 1));
+	
+	Datum *values = palloc0(tupleDesc->natts * sizeof(Datum));
+	bool *nulls = palloc0(tupleDesc->natts * sizeof(bool));
+
+	/* we don't need to know rowNumber here */
+	while (ColumnarReadNextRow(readState, values, nulls, NULL))
+	{
+		ColumnarWriteRow(writeState, values, nulls);
+	}
+	
+	uint64 newDataReservation;
+
+	if (list_length(stripeMetadataList) > startingStripeListPosition)
+	{
+		StripeMetadata *mtd = list_nth(stripeMetadataList, startingStripeListPosition);
+		newDataReservation = mtd->fileOffset + mtd->dataLength - 1;
+	}
+	else
+	{
+		StripeMetadata *mtd = list_nth(stripeMetadataList, startingStripeListPosition - 1);
+		newDataReservation = mtd->fileOffset;
+	}
+
+	ColumnarStorageTruncate(rel, newDataReservation);
+
+	for (int i = 0; i < startingStripeListPosition; i++)
+	{
+		StripeMetadata *metadata = list_nth(stripeMetadataList, i);
+		DeleteMetadataRowsForStripeId(rel->rd_node, metadata->id);
+	}
+
+	ColumnarEndWrite(writeState);
+	ColumnarEndRead(readState);
+
+	return true;
+}
+
 
 /*
  * columnar_vacuum_rel implements VACUUM without FULL option.
@@ -1161,7 +1305,7 @@ LogRelationStats(Relation rel, int elevel)
 	uint64 droppedChunksWithData = 0;
 	uint64 totalDecompressedLength = 0;
 
-	List *stripeList = StripesForRelfilenode(relfilenode);
+	List *stripeList = StripesForRelfilenode(relfilenode, ForwardScanDirection);
 	int stripeCount = list_length(stripeList);
 
 	foreach(stripeMetadataCell, stripeList)
@@ -1299,25 +1443,41 @@ TruncateColumnar(Relation rel, int elevel)
 		return;
 	}
 
+	bool stripesTruncated = TruncateAndCombineColumnarStripes(rel, elevel);
+
 	/*
-	 * Due to the AccessExclusive lock there's no danger that
-	 * new stripes be added beyond highestPhysicalAddress while
-	 * we're truncating.
+	 * If we didn't truncate and combine tail stripes we could have
+	 * stituation where we need to truncate storage at the end.
 	 */
-	uint64 newDataReservation = Max(GetHighestUsedAddress(rel->rd_node) + 1,
-									ColumnarFirstLogicalOffset);
-
-	RelationOpenSmgr(rel);
-	BlockNumber old_rel_pages = smgrnblocks(rel->rd_smgr, MAIN_FORKNUM);
-
-	if (!ColumnarStorageTruncate(rel, newDataReservation))
+	if (!stripesTruncated)
 	{
-		UnlockRelation(rel, AccessExclusiveLock);
-		return;
-	}
 
-	RelationOpenSmgr(rel);
-	BlockNumber new_rel_pages = smgrnblocks(rel->rd_smgr, MAIN_FORKNUM);
+		/*
+		* Due to the AccessExclusive lock there's no danger that
+		* new stripes be added beyond highestPhysicalAddress while
+		* we're truncating.
+		*/
+		uint64 newDataReservation = Max(GetHighestUsedAddress(rel->rd_node) + 1,
+										ColumnarFirstLogicalOffset);
+
+		RelationOpenSmgr(rel);
+		BlockNumber old_rel_pages = smgrnblocks(rel->rd_smgr, MAIN_FORKNUM);
+
+		if (!ColumnarStorageTruncate(rel, newDataReservation))
+		{
+			UnlockRelation(rel, AccessExclusiveLock);
+			return;
+		}
+
+		RelationOpenSmgr(rel);
+		BlockNumber new_rel_pages = smgrnblocks(rel->rd_smgr, MAIN_FORKNUM);
+
+		ereport(elevel,
+		(errmsg("\"%s\": truncated %u to %u pages",
+				RelationGetRelationName(rel),
+				old_rel_pages, new_rel_pages),
+			errdetail_internal("%s", pg_rusage_show(&ru0))));
+	}
 
 	/*
 	 * We can release the exclusive lock as soon as we have truncated.
@@ -1327,12 +1487,6 @@ TruncateColumnar(Relation rel, int elevel)
 	 * they acquire lock on the relation.
 	 */
 	UnlockRelation(rel, AccessExclusiveLock);
-
-	ereport(elevel,
-			(errmsg("\"%s\": truncated %u to %u pages",
-					RelationGetRelationName(rel),
-					old_rel_pages, new_rel_pages),
-			 errdetail_internal("%s", pg_rusage_show(&ru0))));
 }
 
 

--- a/columnar/src/include/columnar/columnar.h
+++ b/columnar/src/include/columnar/columnar.h
@@ -292,6 +292,8 @@ extern void ColumnarReadRowByRowNumberOrError(ColumnarReadState *readState,
 extern bool ColumnarReadRowByRowNumber(ColumnarReadState *readState,
 									   uint64 rowNumber, Datum *columnValues,
 									   bool *columnNulls);
+extern bool ColumnaSetStripeReadState(ColumnarReadState *readState,
+									  StripeMetadata *startStripeMetadata);
 
 /* Function declarations for common functions */
 extern FmgrInfo * GetFunctionInfoOrNull(Oid typeId, Oid accessMethodId,
@@ -313,6 +315,7 @@ extern bool IsColumnarTableAmTable(Oid relationId);
 
 /* columnar_metadata_tables.c */
 extern void DeleteMetadataRows(RelFileNode relfilenode);
+extern void DeleteMetadataRowsForStripeId(RelFileNode relfilenode, uint64 stripeId);
 extern uint64 ColumnarMetadataNewStorageId(void);
 extern uint64 GetHighestUsedAddress(RelFileNode relfilenode);
 extern EmptyStripeReservation * ReserveEmptyStripe(Relation rel, uint64 columnCount,

--- a/columnar/src/include/columnar/columnar_metadata.h
+++ b/columnar/src/include/columnar/columnar_metadata.h
@@ -12,6 +12,8 @@
 #ifndef COLUMNAR_METADATA_H
 #define COLUMNAR_METADATA_H
 
+#include "access/sdir.h"
+
 /*
  * StripeMetadata represents information about a stripe. This information is
  * stored in the metadata table "columnar.stripe".
@@ -49,7 +51,10 @@ typedef struct EmptyStripeReservation
 	uint64 stripeFirstRowNumber;
 } EmptyStripeReservation;
 
-extern List * StripesForRelfilenode(RelFileNode relfilenode);
+extern List * StripesForRelfilenode(RelFileNode relfilenode, ScanDirection scanDirection);
+extern uint32 DeletedRowsForStripe(RelFileNode relfilenode,
+								   uint32 chunkCount,
+								   uint64 stripeId);
 extern void ColumnarStorageUpdateIfNeeded(Relation rel, bool isUpgrade);
 
 #endif /* COLUMNAR_METADATA_H */

--- a/columnar/src/test/regress/expected/columnar_vacuum.out
+++ b/columnar/src/test/regress/expected/columnar_vacuum.out
@@ -289,3 +289,148 @@ SELECT * FROM columnar_test_helpers.chunk_group_consistency;
 (1 row)
 
 DROP TABLE t;
+  -- Vacuuming on multiple stripes
+SET columnar.compression TO default;
+SET columnar.stripe_row_limit TO default;
+SET columnar.chunk_group_row_limit TO default;
+CREATE TABLE t(a INT, b INT) USING columnar;
+INSERT INTO t SELECT g, g % 10 from generate_series(1,100000) g;
+INSERT INTO t SELECT g, g % 10 from generate_series(1,100000) g;
+SELECT COUNT(*) = 2 FROM columnar.stripe;
+ ?column? 
+----------
+ t
+(1 row)
+
+VACUUM t;
+  -- No change since we can't combine 2 stripe because row_number is higher
+  -- than maximum row number per stripe
+SELECT COUNT(*) = 2 FROM columnar.stripe;
+ ?column? 
+----------
+ t
+(1 row)
+
+DELETE FROM t WHERE a % 2 = 0;
+SELECT COUNT(*) = 0 FROM columnar.chunk_group WHERE deleted_rows = 0; 
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT COUNT(*) = 0 FROM columnar.row_mask WHERE deleted_rows = 0; 
+ ?column? 
+----------
+ t
+(1 row)
+
+VACUUM t;
+  -- Stripes are merged into one stripe because total number of non-deleted rows
+  -- is less than maximum stripe row number
+SELECT COUNT(*) = 1 FROM columnar.stripe;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT COUNT(*) FROM columnar.chunk_group WHERE deleted_rows = 0; 
+ count 
+-------
+    10
+(1 row)
+
+SELECT COUNT(*) FROM columnar.row_mask WHERE deleted_rows = 0; 
+ count 
+-------
+    10
+(1 row)
+
+DROP TABLE t;
+  -- Vacuum on single stripe
+CREATE TABLE t(a INT, b INT) USING columnar;
+INSERT INTO t SELECT g, g % 10 from generate_series(1,100000) g;
+SELECT COUNT(*) = (SELECT COUNT(*) FROM columnar.row_mask) FROM columnar.chunk_group;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT COUNT(*) AS columnar_chunk_group_rows FROM columnar.chunk_group \gset
+SELECT COUNT(*) AS columnar_row_mask_rows FROM columnar.row_mask \gset
+DELETE FROM t WHERE a % 2 = 0;
+SELECT COUNT(*) AS columnar_chunk_group_after_delete_rows FROM columnar.chunk_group WHERE deleted_rows >= 1 \gset
+SELECT COUNT(*) AS columnar_row_mask_after_delete_rows FROM columnar.row_mask WHERE deleted_rows >= 1 \gset
+SELECT :columnar_chunk_group_after_delete_rows = :columnar_chunk_group_rows;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT :columnar_row_mask_after_delete_rows = :columnar_row_mask_rows;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT SUM(deleted_rows) FROM columnar.row_mask;
+  sum  
+-------
+ 50000
+(1 row)
+
+SELECT SUM(deleted_rows) FROM columnar.chunk_group;
+  sum  
+-------
+ 50000
+(1 row)
+
+VACUUM t;
+  -- No more deleted_rows after vacuum
+SELECT COUNT(*) = 0 FROM columnar.chunk_group WHERE deleted_rows >= 1;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT COUNT(*) = 0 FROM columnar.row_mask WHERE deleted_rows >= 1;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT COUNT(*) = (:columnar_chunk_group_rows / 2) FROM columnar.chunk_group WHERE deleted_rows = 0;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT COUNT(*) = (:columnar_row_mask_rows / 2) FROM columnar.row_mask WHERE deleted_rows = 0;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT COUNT(*) AS table_count FROM t \gset
+SELECT COUNT(*) AS table_count_mod_7 FROM t WHERE a % 7 = 0 \gset
+SELECT (:table_count_mod_7 / :table_count) < 0.2;
+ ?column? 
+----------
+ t
+(1 row)
+
+DELETE FROM t WHERE a % 7 = 0;
+VACUUM t;
+  -- Vacuuming will not be done because number of deleted rows / total_rows is less than 20%
+SELECT COUNT(*) = (:columnar_chunk_group_rows / 2) FROM columnar.chunk_group;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT COUNT(*) = (:columnar_row_mask_rows / 2) FROM columnar.row_mask ;
+ ?column? 
+----------
+ t
+(1 row)
+
+DROP TABLE t;


### PR DESCRIPTION
Vacuum columnar tables by combining last n stripes until stripe row max count is reached. Vacuuming decision also include information about number of deleted rows of each stripe. If there is only one stripe, vacuum will be done if percentage of deleted rows is higher than 20%.