### PR TITLE
[columnar] [Bug] Sequential scan parallel execution OOM

### DIFF
--- a/columnar/src/backend/columnar/columnar_metadata.c
+++ b/columnar/src/backend/columnar/columnar_metadata.c
@@ -1093,7 +1093,7 @@ FindNextStripeForParallelWorker(Relation relation,
 	ScanKeyData scanKey;
 
 	ScanKeyInit(&scanKey, Anum_columnar_stripe_storageid,
-				BTEqualStrategyNumber, F_OIDEQ, Int32GetDatum(storageId));
+				BTEqualStrategyNumber, F_OIDEQ, UInt64GetDatum(storageId));
 
 	Relation columnarStripes = table_open(ColumnarStripeRelationId(), AccessShareLock);
 
@@ -1120,6 +1120,8 @@ FindNextStripeForParallelWorker(Relation relation,
 				*nextHigherStripeId = foundStripeMetadata->id;
 				break;
 			}
+
+			pfree(foundStripeMetadata);
 		}
 		else
 		{


### PR DESCRIPTION
When assigning next stripe to be read, workers need to scan complete stripe metadata table and reach stripe which need to be read next. During this fetch and compare of stripe metadata rows memory is never released for stripes that needs to be skipped.
This should be addressed by releasing memory that is not needed.

<!-- 
Thanks for opening a pull request to Hydra! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Please make sure your code changes are covered with tests.
- In the case of new features or big changes, remember to adjust the documentation to reflect such features/changes.

Feel free to ping committers for the review!
-->

<!-- Include an overview here -->

### What's changed?
<!-- 
Describe in detail what you've changed.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->
