### PR TITLE
[columnar] [Bug]: Vacuum still fails by hanging indefinitely

### DIFF
--- a/columnar/src/backend/columnar/columnar_metadata.c
+++ b/columnar/src/backend/columnar/columnar_metadata.c
@@ -1363,7 +1363,7 @@ ReadChunkGroupRowCounts(uint64 storageId, uint64 stripe, uint32 chunkGroupCount,
 	HeapTuple heapTuple = NULL;
 
 	*chunkGroupRowCounts = palloc0(chunkGroupCount * sizeof(uint32));
-	*chunkGroupDeletedRows = palloc(chunkGroupCount * sizeof(uint32));
+	*chunkGroupDeletedRows = palloc0(chunkGroupCount * sizeof(uint32));
 
 	/*
 	 * Since we have now updates of `chunk_group`, there could be multiple tuples

--- a/columnar/src/backend/columnar/columnar_tableam.c
+++ b/columnar/src/backend/columnar/columnar_tableam.c
@@ -1189,7 +1189,7 @@ TruncateAndCombineColumnarStripes(Relation rel, int elevel)
 		
 		uint64 stripeRowCount = stripeMetadata->rowCount - lastStripeDeletedRows;
 
-		if ((totalRowNumberCount + stripeRowCount > columnarOptions.stripeRowCount))
+		if ((totalRowNumberCount + stripeRowCount >= columnarOptions.stripeRowCount))
 		{
 			break;
 		}


### PR DESCRIPTION
During vacuum, stripes are collected in reverse order and if row number is greater than defined limit we should stop and combine previous stripe into them into one. Problem is that while writing rows into temporary write state object - this condition is not greater but greater or equal which lead to infinite loop. Fixed by using proper comparison operator when stripe candidates are choosen.

<!-- 
Thanks for opening a pull request to Hydra! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Please make sure your code changes are covered with tests.
- In the case of new features or big changes, remember to adjust the documentation to reflect such features/changes.

Feel free to ping committers for the review!
-->

<!-- Include an overview here -->

### What's changed?
<!-- 
Describe in detail what you've changed.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->
