### PR TITLE
[columnar] add `columnar.max_parallel_processes` setting

### DIFF
--- a/columnar/src/backend/columnar/columnar.c
+++ b/columnar/src/backend/columnar/columnar.c
@@ -43,6 +43,7 @@ int columnar_chunk_group_row_limit = DEFAULT_CHUNK_ROW_COUNT;
 int columnar_compression_level = 3;
 bool columnar_enable_parallel_execution = true;
 int columnar_min_parallel_processes = 8;
+int columnar_max_parallel_processes = 0;
 bool columnar_enable_vectorization = true;
 bool columnar_enable_dml = true;
 
@@ -138,6 +139,19 @@ columnar_init_gucs()
 							&columnar_min_parallel_processes,
 							8,
 							1,
+							32,
+							PGC_USERSET,
+							0,
+							NULL,
+							NULL,
+							NULL);
+	
+	DefineCustomIntVariable("columnar.max_parallel_processes",
+							"Max number of parallel processes per query",
+							NULL,
+							&columnar_max_parallel_processes,
+							0,
+							0,
 							32,
 							PGC_USERSET,
 							0,

--- a/columnar/src/backend/columnar/columnar_customscan.c
+++ b/columnar/src/backend/columnar/columnar_customscan.c
@@ -1232,6 +1232,10 @@ AddColumnarScanPathsRec(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte,
 				Min(max_parallel_workers, columnar_min_parallel_processes);
 		}
 
+		if (columnar_max_parallel_processes)
+			columnar_min_parallel_process_running = 
+				Min(columnar_min_parallel_process_running, columnar_max_parallel_processes);
+
 		if (parallel_leader_participation)
 			columnar_min_parallel_process_running--;
 

--- a/columnar/src/include/columnar/columnar.h
+++ b/columnar/src/include/columnar/columnar.h
@@ -238,6 +238,7 @@ extern int columnar_chunk_group_row_limit;
 extern int columnar_compression_level;
 extern bool columnar_enable_parallel_execution;
 extern int columnar_min_parallel_processes;
+extern int columnar_max_parallel_processes;
 extern bool columnar_enable_vectorization;
 extern bool columnar_enable_dml;
 


### PR DESCRIPTION
* Added `columnar.max_parallel_processes` which will limit max number of processes to be used for query. Default values is set to `0` meaning this will not be considered when planning is done.

<!-- 
Thanks for opening a pull request to Hydra! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Please make sure your code changes are covered with tests.
- In the case of new features or big changes, remember to adjust the documentation to reflect such features/changes.

Feel free to ping committers for the review!
-->

<!-- Include an overview here -->

### What's changed?
<!-- 
Describe in detail what you've changed.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->
