### PR TITLE
add timeouts to all jobs

### DIFF
--- a/.github/workflows/build_spilo.yaml
+++ b/.github/workflows/build_spilo.yaml
@@ -26,6 +26,7 @@ jobs:
     if: github.repository == 'hydradatabase/hydra-internal'
     name: Push Spilo
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
     - name: Checkout
       uses: actions/checkout@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,7 @@ jobs:
   lint_go:
     name: Lint acceptance
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -33,6 +34,7 @@ jobs:
         postgres: ["13", "14", "15"]
     name: Validate Columnar ${{ matrix.postgres }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -58,6 +60,7 @@ jobs:
         postgres: ["13", "14", "15"]
     name: Build and Validate Postgres ${{ matrix.postgres }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: setup POSTGRES_IMAGE env
         run: echo "POSTGRES_IMAGE=${{ format('{0}:{1}-{2}', env.POSTGRES_REPO, matrix.postgres, github.sha) }}" >> $GITHUB_ENV
@@ -113,6 +116,7 @@ jobs:
     if: github.repository == 'hydradatabase/hydra-internal'
     name: Build and Validate Spilo
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: setup SPILO_IMAGE
         run: echo "SPILO_IMAGE=${{ format('{0}:{1}', env.SPILO_REPO, github.sha) }}" >> $GITHUB_ENV
@@ -190,6 +194,7 @@ jobs:
         postgres: ["13", "14", "15"]
     name: Push Postgres ${{ matrix.postgres }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -218,6 +223,7 @@ jobs:
   push_spilo:
     needs: [build_validate_spilo]
     if: github.repository == 'hydradatabase/hydra-internal' && github.ref == 'refs/heads/main'
+    timeout-minutes: 10
     uses: ./.github/workflows/build_spilo.yaml
     with:
       production: true


### PR DESCRIPTION
Per https://github.com/hydradatabase/hydra/pull/82#issuecomment-1551898003 there was a job that ran for almost 2 hours (!) that should have run for only a few minutes.

I think these timeouts are well above what is needed if these are running correctly.