### PR TITLE
set golangci-lint to 1.50.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,6 +27,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           working-directory: acceptance
+          version: v1.50.1
 
   validate_columnar:
     strategy:


### PR DESCRIPTION
pins golangci-lint to 1.50.1

fixes failing CI on main