### PR TITLE
[columnar] fixes edge case for vacuum udf and adds vacuum_full udf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Future release
 
+* add vacuum_full UDF ([#93][])
 * bugfix: vacuum udf could get into a look and overwrite stripes ([#92][])
 * add columnar decompressed chunk cache ([#86][])
 * bugfix: vacuum hanging indefinitely in some cases ([#80][])
@@ -60,6 +61,7 @@
 [#80]: https://github.com/hydradatabase/hydra/pull/80
 [#86]: https://github.com/hydradatabase/hydra/pull/86
 [#92]: https://github.com/hydradatabase/hydra/pull/92
+[#93]: https://github.com/hydradatabase/hydra/pull/93
 [02d2253]: https://github.com/hydradatabase/hydra/commit/02d2253
 [0d41837]: https://github.com/hydradatabase/hydra/commit/0d41837
 [15193be]: https://github.com/hydradatabase/hydra/commit/15193be

--- a/columnar/src/backend/columnar/sql/udfs/vacuum/11.1-6.sql
+++ b/columnar/src/backend/columnar/sql/udfs/vacuum/11.1-6.sql
@@ -16,3 +16,42 @@ CREATE OR REPLACE FUNCTION columnar.stats(
 ) RETURNS SETOF record
 LANGUAGE c
 AS 'MODULE_PATHNAME', $$columnar_stats$$;
+
+COMMENT ON FUNCTION columnar.stats(regclass)
+  IS 'columnar stripe statistics';
+
+CREATE OR REPLACE FUNCTION columnar.vacuum_full(schema NAME DEFAULT 'public', sleep_time REAL DEFAULT .1, stripe_count INT DEFAULT 25)
+RETURNS VOID AS $$
+DECLARE
+  tables REGCLASS[];
+  tablename REGCLASS;
+  finished BOOL;
+  count INT;
+BEGIN
+  SELECT ARRAY_AGG(c.relname) INTO tables
+  FROM pg_catalog.pg_class c
+      LEFT JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+      LEFT JOIN pg_catalog.pg_am am ON am.oid = c.relam
+  WHERE c.relkind = 'r'
+        AND n.nspname <> 'pg_catalog'
+        AND n.nspname !~ '^pg_toast'
+        AND n.nspname <> 'information_schema'
+    AND pg_catalog.pg_table_is_visible(c.oid)
+    AND am.amname = 'columnar'
+    AND n.nspname = schema
+  ORDER BY 1;
+
+  FOREACH tablename IN ARRAY tables
+  LOOP
+    finished := 'f';
+    count := 1;
+    WHILE count > 0 LOOP
+      SELECT columnar.vacuum(tablename, stripe_count) INTO count;
+      PERFORM pg_sleep(sleep_time);
+    END LOOP;
+  END LOOP;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION columnar.vacuum_full(name, real, int)
+  IS 'vacuum columnar schema in full incrementally';

--- a/columnar/src/backend/columnar/sql/udfs/vacuum/latest.sql
+++ b/columnar/src/backend/columnar/sql/udfs/vacuum/latest.sql
@@ -16,3 +16,42 @@ CREATE OR REPLACE FUNCTION columnar.stats(
 ) RETURNS SETOF record
 LANGUAGE c
 AS 'MODULE_PATHNAME', $$columnar_stats$$;
+
+COMMENT ON FUNCTION columnar.stats(regclass)
+  IS 'columnar stripe statistics';
+
+CREATE OR REPLACE FUNCTION columnar.vacuum_full(schema NAME DEFAULT 'public', sleep_time REAL DEFAULT .1, stripe_count INT DEFAULT 25)
+RETURNS VOID AS $$
+DECLARE
+  tables REGCLASS[];
+  tablename REGCLASS;
+  finished BOOL;
+  count INT;
+BEGIN
+  SELECT ARRAY_AGG(c.relname) INTO tables
+  FROM pg_catalog.pg_class c
+      LEFT JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+      LEFT JOIN pg_catalog.pg_am am ON am.oid = c.relam
+  WHERE c.relkind = 'r'
+        AND n.nspname <> 'pg_catalog'
+        AND n.nspname !~ '^pg_toast'
+        AND n.nspname <> 'information_schema'
+    AND pg_catalog.pg_table_is_visible(c.oid)
+    AND am.amname = 'columnar'
+    AND n.nspname = schema
+  ORDER BY 1;
+
+  FOREACH tablename IN ARRAY tables
+  LOOP
+    finished := 'f';
+    count := 1;
+    WHILE count > 0 LOOP
+      SELECT columnar.vacuum(tablename, stripe_count) INTO count;
+      PERFORM pg_sleep(sleep_time);
+    END LOOP;
+  END LOOP;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION columnar.vacuum_full(name, real, int)
+  IS 'vacuum columnar schema in full incrementally';

--- a/columnar/src/test/regress/expected/columnar_vacuum_udf.out
+++ b/columnar/src/test/regress/expected/columnar_vacuum_udf.out
@@ -226,7 +226,7 @@ DELETE FROM t1 WHERE a BETWEEN 500000 AND 1500000;
 SELECT * FROM columnar.vacuum('t1'::regclass);
  vacuum 
 --------
-     17
+     18
 (1 row)
 
 -- should show no holes
@@ -238,7 +238,7 @@ SELECT * FROM columnar.stats('t1'::regclass);
        16 |    1640581 |   150000 |           0 |         15 |     813704
        17 |    2454285 |   100000 |           0 |         10 |     543338
        18 |    2997623 |   150000 |           0 |         15 |     819245
-       19 |     825084 |    50000 |           0 |          5 |     271619
+       19 |    3816868 |    50000 |           0 |          5 |     271619
 (6 rows)
 
 DROP TABLE t1;
@@ -356,7 +356,7 @@ UPDATE t1 SET i4 = null where i4 % 23 = 0;
 SELECT columnar.vacuum('t1');
  vacuum 
 --------
-     94
+     97
 (1 row)
 
 SELECT count(i1), count(i2), count(i3), count(i4) FROM t1;

--- a/columnar/src/test/regress/expected/columnar_vacuum_udf_1.out
+++ b/columnar/src/test/regress/expected/columnar_vacuum_udf_1.out
@@ -226,7 +226,7 @@ DELETE FROM t1 WHERE a BETWEEN 500000 AND 1500000;
 SELECT * FROM columnar.vacuum('t1'::regclass);
  vacuum 
 --------
-     17
+     18
 (1 row)
 
 -- should show no holes
@@ -238,7 +238,7 @@ SELECT * FROM columnar.stats('t1'::regclass);
        16 |    1640580 |   150000 |           0 |         15 |     813703
        17 |    2454283 |   100000 |           0 |         10 |     543336
        18 |    2997619 |   150000 |           0 |         15 |     819249
-       19 |     825083 |    50000 |           0 |          5 |     271618
+       19 |    3816868 |    50000 |           0 |          5 |     271618
 (6 rows)
 
 DROP TABLE t1;
@@ -356,7 +356,7 @@ UPDATE t1 SET i4 = null where i4 % 23 = 0;
 SELECT columnar.vacuum('t1');
  vacuum 
 --------
-     94
+     97
 (1 row)
 
 SELECT count(i1), count(i2), count(i3), count(i4) FROM t1;


### PR DESCRIPTION
# Two Parts

1. Fixes an edge case on the vacuum UDF where the state of holes can get weird, instead of calculating, just retrieve the state as needed after a change.  This is less performant, but more correct.
2. Adds `columnar.vacuum_full()` UDF that allows for the full vacuum of a schema of columnar tables as a convenience function.

## columnar.vacuum_full(schema, sleep_time, stripe_count)

This is a convenience function that allows for a full incremental vacuum to be called to vacuum a full schema incrementally, table by table.

|Argument|Type|Description|Default|
|----------|-----|-----------|-------|
|schema|`name`|Schema to vacuum, will query for any tables|`public`|
|sleep_time|`real`|Amount of time to wait between each call of the `columnar.vacuum` UDF in seconds (uses `pg_sleep`)|`0.1`|
|stripe_count|`int`|Number of `stripes` to attempt to vacuum between `pg_sleep` calls|`25`|

### Usage

```
SELECT columnar.vacuum_full();
SELECT columnar.vacuum_full('public', 0.1, 25);
SELECT columnar.vacuum_full(sleep_time => 1.5);
```
