### PR TITLE
[columnar] Adjust plan for parallel workers

### DIFF
--- a/columnar/src/backend/columnar/columnar_customscan.c
+++ b/columnar/src/backend/columnar/columnar_customscan.c
@@ -94,7 +94,6 @@ static void CostColumnarPaths(PlannerInfo *root, RelOptInfo *rel, Oid relationId
 static void CostColumnarIndexPath(PlannerInfo *root, RelOptInfo *rel, Oid relationId,
 								  IndexPath *indexPath);
 static void CostColumnarSeqPath(RelOptInfo *rel, Oid relationId, Path *path);
-static void AdjustColumnarParallelScanCost(Path *path);
 static void CostColumnarScan(PlannerInfo *root, RelOptInfo *rel, Oid relationId,
 							 CustomPath *cpath, int numberOfColumnsRead,
 							 int nClauses);
@@ -1256,7 +1255,6 @@ AddColumnarScanPathsRec(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte,
 
 			parallelColumnarScanPath->parallel_workers = columnar_min_parallel_process_running;
 			parallelColumnarScanPath->parallel_aware = true;
-			AdjustColumnarParallelScanCost(parallelColumnarScanPath);
 
 			add_partial_path(rel, parallelColumnarScanPath);
 		}
@@ -1464,36 +1462,6 @@ AddColumnarScanPath(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte,
 
 	return path;
 }
-
-
-/*
- * AdjustColumnarParallelScanCost calculates path cost based on
- * number of parallel workers (based on postgres code).
- */
-static void
-AdjustColumnarParallelScanCost(Path *path) 
-{
-	/* Adjust costing for parallelism, if used. */
-	if (path->parallel_workers > 0)
-	{
-		double parallel_divisor = path->parallel_workers;
-
-		if (parallel_leader_participation)
-		{
-			double leader_contribution;
-
-			leader_contribution = 1.0 - (0.3 * path->parallel_workers);
-			if (leader_contribution > 0)
-				parallel_divisor += leader_contribution;
-		}
-
-		/* The CPU cost is divided among all the workers. */
-		path->total_cost /= parallel_divisor;
-
-		path->rows = clamp_row_est(path->rows / parallel_divisor);
-	}
-}
-
 
 /*
  * CostColumnarScan calculates the cost of scanning the columnar table. The


### PR DESCRIPTION
# Why?

Through the process of benchmarking, I found a regression that caused some queries to create such a bad plan that they never returned (I let them go for over 24 hours in some cases).

This is an attempt to fix that.  I've tried to strike a balance as much as I can, and did ~100 iterations of this PR to try to find the best balance.

Likely, we can spend more time and generate better plans (as found in the TPC-H like benchmarks), but this seemed to be a good compromise between never returning and faster in some cases.

Ultimately, we should not be messing with the `total_cost` as much as we are, and need to revisit what we would gain and lose from changing this value.

Tests were run with multiple values of parallelism, and the results had the same amount of variance.

Ultimately, I believe that being able to finish queries currently trumps any performance losses.  We can revisit this later.

## Benchmarks

Benchmarks are a mixed bag.  In most cases, this PR is slightly better for Clickbench, sometimes a lot better, and sometimes slightly worse.

For TPC-H like workloads, this solves some queries never being able to be finished, but also slows down some specific queries, but does actually speed up some others.

Times are in milliseconds, and can have some variation, but were run multiple times to hopefully lower that variation as much as possible.

### Clickbench

|query|main|this PR|
|-----|----|-------|
|1|456.31600000000003|460.59366666666665|
|2|220.354|210.96433333333334|
|3|808.0383333333333|783.6193333333334|
|4|640.5033333333332|622.459|
|5|15472.485666666667|15466.510666666669|
|6|21994.031000000003|22213.421666666673|
|7|625.0406666666667|602.093|
|8|215.79233333333332|203.43866666666668|
|9|30922.437666666665|28895.963666666667|
|10|30872.015333333333|34180.00066666667|
|11|2051.9953333333333|2249.9779999999996|
|12|2036.8149999999998|2725.6133333333332|
|13|4817.717333333333|4883.203333333334|
|14|6694.588333333333|11167.004|
|15|7361.393|7644.916666666667|
|16|7927.185666666667|7957.927|
|17|23980.143|24600.210000000003|
|18|6203.916|6296.226|
|19|28134.34933333333|30042.918|
|20|129.98533333333333|129.66466666666665|
|21|2643.155|2644.423|
|22|2749.924333333334|2708.9363333333336|
|23|4192.029|4170.561333333333|
|24|21699.229666666666|21561.302|
|25|1113.0653333333332|1096.46|
|26|760.91|756.7189999999999|
|27|1105.6663333333333|1089.1213333333335|
|28|3587.748333333333|3603.753|
|29|48929.538|49286.85766666667|
|30|7329.293333333332|7354.826666666667|
|31|7877.797666666666|5811.288666666667|
|32|14117.553|8659.109666666665|
|33|111166.50466666667|59964.71300000001|
|34|24676.078666666665|23365.491333333335|
|35|23301.183|23540.811|
|36|7642.1179999999995|7408.449333333333|
|37|508.4170000000001|514.8843333333333|
|38|358.9823333333333|327.50333333333333|
|39|172.535|164.18433333333334|
|40|1368.5233333333333|1431.0503333333334|
|41|177.321|135.40433333333334|
|42|155.01466666666667|156.11766666666665|
|43|205.04166666666666|202.49966666666668|

### TPC-H like

|query|main|this PR|
|-----|----|-------|
|1|4468.7390000000005|4472.506|
|2|108332.404|108058.87566666666|
|3|2656.4836666666665|13069.858333333332|
|4|1993.4623333333332|19961.212|
|5|130762.24466666667|131703.59566666666|
|6|931.8263333333333|928.4516666666667|
|7|1567.1766666666665|18794.769|
|8|2201.2990000000004|4581.599|
|9|547614.9735000001|539050.5876666666|
|10|11627.847666666668|11817.461666666668|
|11|1184.0003333333334|1174.5786666666665|
|12|does not finish|3158.556|
|13|2106.2763333333332|12766.124666666665|
|14|1704.9873333333335|1724.4293333333335|
|15|640.8744444444444|621.673111111111|
|16|704.0210000000001|3196.8620000000005|
|17|41149.009|40725.539666666664|
|18|237956.76300000004|240631.81999999998|
|19|10328.682999999999|10350.044666666667|
|20|12044.598666666667|11002.759|
|21|9204.325666666666|11289.926|
|22|696.8396666666666|989.6253333333333|

