### PR TITLE
[ci] turn off fail-fast for pg version matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,6 +37,7 @@ jobs:
 
   validate_columnar:
     strategy:
+      fail-fast: false
       matrix:
         postgres: ["13", "14", "15"]
     name: Validate Columnar ${{ matrix.postgres }}
@@ -63,6 +64,7 @@ jobs:
   build_validate_postgres:
     needs: [validate_columnar]
     strategy:
+      fail-fast: false
       matrix:
         postgres: ["13", "14", "15"]
     name: Build and Validate Postgres ${{ matrix.postgres }}
@@ -197,6 +199,7 @@ jobs:
     needs: [build_validate_postgres]
     if: github.repository == 'hydradatabase/hydra' && github.ref == 'refs/heads/main'
     strategy:
+      fail-fast: false
       matrix:
         postgres: ["13", "14", "15"]
     name: Push Postgres ${{ matrix.postgres }}


### PR DESCRIPTION
In most cases, the build is most likely to fail nearly simultaneously, so this will let each build run until it errors rather than aborting just before it was likely to fail, confirming the problem is not version specific.

In cases where the problem is version specific, this will inform us if the problem is actually specific to a particular version of Postgres.