### PR TITLE
Upgrade open source Postgres image from bullseye to bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,21 +5,21 @@ FROM postgres_base
 ARG PYTHON_VERSION
 
 RUN set -eux; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
-        # http deps
-        ca-certificates \
-        libcurl4-gnutls-dev \
-        # mysql deps
-        default-libmysqlclient-dev \
-        # multicorn deps
-        python${PYTHON_VERSION} \
-        python${PYTHON_VERSION}-dev \
-        # s3 deps
-        lsb-release \
-        wget \
-	; \
-	rm -rf /var/lib/apt/lists/*
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+    # http deps
+    ca-certificates \
+    libcurl4-gnutls-dev \
+    # mysql deps
+    default-libmysqlclient-dev \
+    # multicorn deps
+    python${PYTHON_VERSION} \
+    python${PYTHON_VERSION}-dev \
+    # s3 deps
+    lsb-release \
+    wget \
+    ; \
+    rm -rf /var/lib/apt/lists/*
 
 # mysql ext
 COPY --from=mysql /pg_ext /

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -23,7 +23,7 @@ variable "SPILO_POSTGRES_OLD_VERSIONS" {
 }
 
 variable "PYTHON_VERSION" {
-  default = "3.9"
+  default = "3.11"
 }
 
 group "default" {
@@ -41,7 +41,7 @@ target "postgres" {
   inherits = ["shared"]
 
   contexts = {
-    postgres_base = "docker-image://postgres:${POSTGRES_BASE_VERSION}-bullseye"
+    postgres_base = "docker-image://postgres:${POSTGRES_BASE_VERSION}-bookworm"
 
     columnar = "target:columnar_${POSTGRES_BASE_VERSION}"
     http = "target:http_${POSTGRES_BASE_VERSION}"
@@ -52,6 +52,7 @@ target "postgres" {
   }
 
   args = {
+    POSTGRES_BASE_VERSION = "${POSTGRES_BASE_VERSION}"
     PYTHON_VERSION = "${PYTHON_VERSION}"
   }
 
@@ -170,7 +171,7 @@ target "s3" {
 
   args = {
     ARROW_TAG = "apache-arrow-10.0.0"
-    AWS_SDK_TAG = "1.10.4"
+    AWS_SDK_TAG = "1.10.57"
     PARQUET_S3_FDW_COMMIT = "3798786831635e5b9cce5dbf33826541c3852809"
   }
 }
@@ -179,7 +180,7 @@ target "s3_13" {
   inherits = ["s3"]
 
   contexts = {
-    postgres_base = "docker-image://postgres:13-bullseye"
+    postgres_base = "docker-image://postgres:13-bookworm"
   }
 
   args = {
@@ -194,7 +195,7 @@ target "s3_15" {
   inherits = ["s3"]
 
   contexts = {
-    postgres_base = "docker-image://postgres:15-bullseye"
+    postgres_base = "docker-image://postgres:15-bookworm"
   }
 
   args = {
@@ -209,7 +210,7 @@ target "s3_14" {
   inherits = ["s3"]
 
   contexts = {
-    postgres_base = "docker-image://postgres:14-bullseye"
+    postgres_base = "docker-image://postgres:14-bookworm"
   }
 
   args = {
@@ -279,7 +280,7 @@ target "mysql_13" {
   inherits = ["mysql"]
 
   contexts = {
-    postgres_base = "docker-image://postgres:13-bullseye"
+    postgres_base = "docker-image://postgres:13-bookworm"
   }
 
   args = {
@@ -294,7 +295,7 @@ target "mysql_14" {
   inherits = ["mysql"]
 
   contexts = {
-    postgres_base = "docker-image://postgres:14-bullseye"
+    postgres_base = "docker-image://postgres:14-bookworm"
   }
 
   args = {
@@ -309,7 +310,7 @@ target "mysql_15" {
   inherits = ["mysql"]
 
   contexts = {
-    postgres_base = "docker-image://postgres:15-bullseye"
+    postgres_base = "docker-image://postgres:15-bookworm"
   }
 
   args = {
@@ -327,7 +328,7 @@ target "multicorn" {
 
   args = {
     PYTHON_VERSION = "${PYTHON_VERSION}"
-    MULTICORN_TAG  = "v2.4"
+    MULTICORN_TAG  = "b68b75c253be72bdfd5b24bf76705c47c238d370"
     S3CSV_FDW_COMMIT = "f64e24f9fe3f7dbd1be76f9b8b3b5208f869e5e3"
     GSPREADSHEET_FDW_COMMIT = "d5bc5ae0b2d189abd6d2ee4610bd96ec39602594"
   }
@@ -337,7 +338,7 @@ target "multicorn_13" {
   inherits = ["multicorn"]
 
   contexts = {
-    postgres_base = "docker-image://postgres:13-bullseye"
+    postgres_base = "docker-image://postgres:13-bookworm"
   }
 
   args = {
@@ -352,7 +353,7 @@ target "multicorn_14" {
   inherits = ["multicorn"]
 
   contexts = {
-    postgres_base = "docker-image://postgres:14-bullseye"
+    postgres_base = "docker-image://postgres:14-bookworm"
   }
 
   args = {
@@ -367,7 +368,7 @@ target "multicorn_15" {
   inherits = ["multicorn"]
 
   contexts = {
-    postgres_base = "docker-image://postgres:15-bullseye"
+    postgres_base = "docker-image://postgres:15-bookworm"
   }
 
   args = {
@@ -431,7 +432,7 @@ target "ivm_13" {
   inherits = ["ivm"]
 
   contexts = {
-    postgres_base = "docker-image://postgres:13-bullseye"
+    postgres_base = "docker-image://postgres:13-bookworm"
   }
 
   args = {
@@ -446,7 +447,7 @@ target "ivm_14" {
   inherits = ["ivm"]
 
   contexts = {
-    postgres_base = "docker-image://postgres:14-bullseye"
+    postgres_base = "docker-image://postgres:14-bookworm"
   }
 
   args = {
@@ -461,7 +462,7 @@ target "ivm_15" {
   inherits = ["ivm"]
 
   contexts = {
-    postgres_base = "docker-image://postgres:15-bullseye"
+    postgres_base = "docker-image://postgres:15-bookworm"
   }
 
   args = {
@@ -486,7 +487,7 @@ target "ivm_13" {
   inherits = ["ivm"]
 
   contexts = {
-    postgres_base = "docker-image://postgres:13-bullseye"
+    postgres_base = "docker-image://postgres:13-bookworm"
   }
 
   args = {
@@ -501,7 +502,7 @@ target "ivm_14" {
   inherits = ["ivm"]
 
   contexts = {
-    postgres_base = "docker-image://postgres:14-bullseye"
+    postgres_base = "docker-image://postgres:14-bookworm"
   }
 
   args = {
@@ -516,7 +517,7 @@ target "ivm_15" {
   inherits = ["ivm"]
 
   contexts = {
-    postgres_base = "docker-image://postgres:15-bullseye"
+    postgres_base = "docker-image://postgres:15-bookworm"
   }
 
   args = {

--- a/third-party/multicorn/Dockerfile
+++ b/third-party/multicorn/Dockerfile
@@ -34,9 +34,6 @@ RUN set -eux; \
   python${PYTHON_VERSION}-dev \
   python${PYTHON_VERSION}-venv
 
-# Update pip to the latest
-#RUN wget https://bootstrap.pypa.io/get-pip.py && python${PYTHON_VERSION} get-pip.py && rm get-pip.py
-
 FROM setup as builder
 
 RUN git clone https://github.com/pgsql-io/multicorn2 --single-branch && \
@@ -46,25 +43,16 @@ RUN git clone https://github.com/pgsql-io/multicorn2 --single-branch && \
   . .venv/bin/activate && \
   DESTDIR=/pg_ext USE_PGXS=1 make && \
   DESTDIR=/pg_ext USE_PGXS=1 make install && \
-  # install runtime python deps
+  # install s3csv_fdw
   python3 -m pip install \
   git+https://github.com/hydradatabase/s3csv_fdw@${S3CSV_FDW_COMMIT} \
-  # gspreadsheet_fdw deps
-  gspread \
-  oauth2client
-
-# Use a fork
-RUN git clone https://github.com/hydradatabase/gspreadsheet_fdw --single-branch && \
-  cd gspreadsheet_fdw && \
-  python${PYTHON_VERSION} -m venv .venv && \
-  . .venv/bin/activate && \
-  git checkout ${GSPREADSHEET_FDW_COMMIT} && \
-  python3 setup.py install
+  # install gspreadsheet_fdw
+  gspread oauth2client \
+  git+https://github.com/hydradatabase/gspreadsheet_fdw@${GSPREADSHEET_FDW_COMMIT}
 
 FROM scratch as output
 
 ARG PYTHON_VERSION
 
 COPY --from=builder /pg_ext /pg_ext
-COPY --from=builder /gspreadsheet_fdw/.venv/lib/python${PYTHON_VERSION}/site-packages /python-dist-packages
 COPY --from=builder /multicorn2/.venv/lib/python${PYTHON_VERSION}/site-packages /python-dist-packages

--- a/third-party/multicorn/Dockerfile
+++ b/third-party/multicorn/Dockerfile
@@ -9,57 +9,62 @@ ARG S3CSV_FDW_COMMIT
 ARG GSPREADSHEET_FDW_COMMIT
 ARG POSTGRES_BASE_VERSION=14
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install gnupg postgresql-common git -y
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install gnupg2 postgresql-common git -y
 RUN sh /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
 RUN set -eux; \
-    export DEBIAN_FRONTEND=noninteractive && \
-    apt-get update; \
-    apt-get upgrade -y; \
-    apt-get install -y \
-      postgresql-${POSTGRES_BASE_VERSION} \
-      postgresql-server-dev-${POSTGRES_BASE_VERSION} \
-      git \
-      build-essential \
-      libreadline-dev \
-      zlib1g-dev \
-      wget \
-      flex \
-      bison \
-      libxml2-dev \
-      libxslt-dev \
-      libssl-dev \
-      libxml2-utils \
-      xsltproc \
-      python${PYTHON_VERSION} \
-      python${PYTHON_VERSION}-dev \
-      python3-pip
+  export DEBIAN_FRONTEND=noninteractive && \
+  apt-get update; \
+  apt-get upgrade -y; \
+  apt-get install -y \
+  postgresql-${POSTGRES_BASE_VERSION} \
+  postgresql-server-dev-${POSTGRES_BASE_VERSION} \
+  git \
+  build-essential \
+  libreadline-dev \
+  zlib1g-dev \
+  wget \
+  flex \
+  bison \
+  libxml2-dev \
+  libxslt-dev \
+  libssl-dev \
+  libxml2-utils \
+  xsltproc \
+  python${PYTHON_VERSION} \
+  python${PYTHON_VERSION}-dev \
+  python${PYTHON_VERSION}-venv
 
 # Update pip to the latest
-RUN wget https://bootstrap.pypa.io/get-pip.py && python3 get-pip.py && rm get-pip.py
+#RUN wget https://bootstrap.pypa.io/get-pip.py && python${PYTHON_VERSION} get-pip.py && rm get-pip.py
 
 FROM setup as builder
 
-RUN git clone https://github.com/pgsql-io/multicorn2 --branch ${MULTICORN_TAG} --single-branch && \
+RUN git clone https://github.com/pgsql-io/multicorn2 --single-branch && \
   cd multicorn2 && \
+  git checkout ${MULTICORN_TAG} && \
+  python${PYTHON_VERSION} -m venv .venv && \
+  . .venv/bin/activate && \
   DESTDIR=/pg_ext USE_PGXS=1 make && \
-  DESTDIR=/pg_ext USE_PGXS=1 make install
-
-# install runtime python deps
-RUN python3 -m pip install \
-    git+https://github.com/hydradatabase/s3csv_fdw@${S3CSV_FDW_COMMIT} \
-    # gspreadsheet_fdw deps
-    gspread \
-    oauth2client
+  DESTDIR=/pg_ext USE_PGXS=1 make install && \
+  # install runtime python deps
+  python3 -m pip install \
+  git+https://github.com/hydradatabase/s3csv_fdw@${S3CSV_FDW_COMMIT} \
+  # gspreadsheet_fdw deps
+  gspread \
+  oauth2client
 
 # Use a fork
 RUN git clone https://github.com/hydradatabase/gspreadsheet_fdw --single-branch && \
-    cd gspreadsheet_fdw && \
-    git checkout ${GSPREADSHEET_FDW_COMMIT} && \
-    python3 setup.py install
+  cd gspreadsheet_fdw && \
+  python${PYTHON_VERSION} -m venv .venv && \
+  . .venv/bin/activate && \
+  git checkout ${GSPREADSHEET_FDW_COMMIT} && \
+  python3 setup.py install
 
 FROM scratch as output
 
 ARG PYTHON_VERSION
 
 COPY --from=builder /pg_ext /pg_ext
-COPY --from=builder /usr/local/lib/python${PYTHON_VERSION}/dist-packages /python-dist-packages
+COPY --from=builder /gspreadsheet_fdw/.venv/lib/python${PYTHON_VERSION}/site-packages /python-dist-packages
+COPY --from=builder /multicorn2/.venv/lib/python${PYTHON_VERSION}/site-packages /python-dist-packages


### PR DESCRIPTION
### What's changed?

Spilo bases on ubuntu:jammy/ubuntu:22.04 which in turns bases on debian:bookworm. But the open source Postgres image still bases on debian:bullseye which can cause issues long term for extensions because the base image is different between Spilo & open source Postgres.