### PR TITLE
Install `pg_vector` extension with `pgxman`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,3 +47,12 @@ COPY --from=ivm /pg_ivm /
 COPY --from=columnar /pg_ext /
 
 COPY files/postgres/docker-entrypoint-initdb.d /docker-entrypoint-initdb.d/
+
+# Install pgxman extensions
+ARG POSTGRES_BASE_VERSION
+# Always force rebuild of this layer
+ARG TIMESTAMP=1
+COPY third-party/pgxman_install.sh /tmp/pgxman_install.sh
+RUN set -eux; \
+    /tmp/pgxman_install.sh ${POSTGRES_BASE_VERSION}; \
+    rm -f /tmp/pgxman_install.sh

--- a/Dockerfile.spilo
+++ b/Dockerfile.spilo
@@ -22,7 +22,7 @@ RUN set -eux; \
     # s3 deps
     lsb-release \
     wget \
-	; \
+    ; \
     rm -rf /var/lib/apt/lists/*
 
 # mysql ext
@@ -70,3 +70,11 @@ COPY files/spilo/postgres-appliance/pgq_ticker.ini /home/postgres/
 ARG POSTGRES_BASE_VERSION
 # Default envs
 ENV PGVERSION=${POSTGRES_BASE_VERSION} SPILO_PROVIDER=local PGUSER_SUPERUSER=postgres PGPASSWORD_SUPERUSER=hydra
+
+# Install pgxman extensions
+# Always force rebuild of this layer
+ARG TIMESTAMP=1
+COPY third-party/pgxman_install.sh /tmp/pgxman_install.sh
+RUN set -eux; \
+    /tmp/pgxman_install.sh 13,14; \
+    rm -f /tmp/pgxman_install.sh

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -35,6 +35,10 @@ target "shared" {
     "linux/amd64",
     "linux/arm64"
   ]
+
+  args = {
+    TIMESTAMP = "${timestamp()}"
+  }
 }
 
 target "postgres" {

--- a/files/spilo/postgres-appliance/scripts/configure_spilo.py
+++ b/files/spilo/postgres-appliance/scripts/configure_spilo.py
@@ -310,7 +310,7 @@ postgresql:
     pg_stat_statements.track_utility: 'off'
     extwlist.extensions: 'btree_gin,btree_gist,citext,extra_window_functions,first_last_agg,hll,\
 hstore,hypopg,intarray,ltree,pgcrypto,pgq,pgq_node,pg_ivm,pg_trgm,postgres_fdw,mysql_fdw,multicorn,\
-parquet_s3_fdw,tablefunc,uuid-ossp'
+parquet_s3_fdw,vector,tablefunc,uuid-ossp'
     extwlist.custom_path: /scripts
     cron.use_background_workers: 'on'
   pg_hba:

--- a/third-party/pgxman_install.sh
+++ b/third-party/pgxman_install.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+main() {
+  local pg_version="$1"
+
+  get_architecture || return 1
+  local _arch="$RETVAL"
+
+  echo "Installing PGXMan extensions for PostgreSQL $pg_version..."
+
+  wget -O "/tmp/pgxman_linux_${_arch}.deb" "https://github.com/pgxman/release/releases/latest/download/pgxman_linux_${_arch}.deb"
+  apt install "/tmp/pgxman_linux_${_arch}.deb"
+
+  pgxman update
+
+  local _extensions=(
+    "pgvector=0.4.4"
+  )
+  local _packages=()
+  for _ext in "${_extensions[@]}"; do
+    _packages+=("$(printf "%s@%s " "$_ext" "$pg_version")")
+  done
+  printf -v _packages_args '%s ' "${_packages[@]}"
+
+  pgxman install $_packages_args
+}
+
+get_architecture() {
+  local _cputype _arch
+  _cputype="$(uname -m)"
+
+  case "$_cputype" in
+  i386 | i486 | i686 | i786 | x86)
+    _cputype=386
+    ;;
+
+  xscale | arm | armv6l | armv7l | armv8l)
+    _cputype=arm
+    ;;
+
+  aarch64 | arm64)
+    _cputype=arm64
+    ;;
+
+  x86_64 | x86-64 | x64 | amd64)
+    _cputype=amd64
+    ;;
+
+  *)
+    err "unknown CPU type: $_cputype"
+    ;;
+  esac
+
+  RETVAL="$_cputype"
+}
+
+main "$@" || exit 1


### PR DESCRIPTION
### What's changed?

* Install `pg_vector` extension with `pgxman`. Note that it's intentional to always force installing extensions with `pgxman` for now to avoid Docker layer caching in case there are any updates made to the extension packages.
* Add acceptance tests to validate `pg_vector` is working as expected.

A demo of `pg_vector` running with the built image:

```psql
postgres=# create extension vector;
CREATE EXTENSION
postgres=# CREATE TABLE items (id bigserial PRIMARY KEY, embedding vector(3));
CREATE TABLE
postgres=# INSERT INTO items (embedding) VALUES ('[1,2,3]'), ('[4,5,6]');
INSERT 0 2
postgres=# SELECT * FROM items ORDER BY embedding <-> '[3,1,2]' LIMIT 5;
 id | embedding 
----+-----------
  1 | [1,2,3]
  2 | [4,5,6]
(2 rows)

```

