### PR TITLE
spilo: remove quotes around db_name

### DIFF
--- a/files/spilo/postgres-appliance/scripts/post_init.sh
+++ b/files/spilo/postgres-appliance/scripts/post_init.sh
@@ -197,7 +197,7 @@ UPDATE pg_catalog.pg_extension SET extname = 'columnar' WHERE extname = 'citus_c
 UPDATE pg_catalog.pg_proc SET probin = '\$libdir/columnar' WHERE probin = '\$libdir/citus_columnar';
 CREATE EXTENSION IF NOT EXISTS columnar;
 ALTER EXTENSION columnar UPDATE;
-ALTER DATABASE \"${db_name}\" SET default_table_access_method = 'columnar';
+ALTER DATABASE ${db_name} SET default_table_access_method = 'columnar';
 GRANT EXECUTE ON FUNCTION public.set_user(text) TO admin;
 GRANT EXECUTE ON FUNCTION public.pg_stat_statements_reset($RESET_ARGS) TO admin;"
     if [ "$PGVER" -lt 10 ]; then


### PR DESCRIPTION
this avoids double quoting since pg_catalog.quote_ident(datname) will add quotes if needed