### PR TITLE
[columnar] fixes a state where an explain with cache on can cause a crash

### DIFF
--- a/columnar/src/backend/columnar/columnar_cache.c
+++ b/columnar/src/backend/columnar/columnar_cache.c
@@ -84,6 +84,7 @@ MemoryContext ColumnarCacheMemoryContext(void)
 	{
 		columnarCacheContext = AllocSetContextCreate(TopMemoryContext, "Columnar Decompression Cache", 0, (uint64) (columnar_page_cache_size * 1024 * 1024 * .1), columnar_page_cache_size * 1024 * 1024);
 		memset(&statistics, 0, sizeof(ColumnarCacheStatistics));
+		head = NULL;
 	}
 
 	return columnarCacheContext;
@@ -332,6 +333,11 @@ void *ColumnarRetrieveCache(uint64 relId, uint64 stripeId, uint64 chunkId, uint3
 static uint64 ColumnarCacheLength()
 {
 	uint64 count = 0;
+
+	if (head == NULL)
+	{
+		return 0;
+	}
 
 	dlist_iter iter;
 	dlist_foreach(iter, head)

--- a/columnar/src/backend/columnar/columnar_tableam.c
+++ b/columnar/src/backend/columnar/columnar_tableam.c
@@ -1219,6 +1219,11 @@ TruncateAndCombineColumnarStripes(Relation rel, int elevel)
 		startingStripeListPosition++;
 	}
 
+	if (startingStripeListPosition == 0)
+	{
+		return false;
+	}
+
 	/* 
 	 * There is only one stripe that is candidate. Maybe we should vacuum
 	 * it if condition is met.

--- a/columnar/src/test/regress/expected/columnar_cache.out
+++ b/columnar/src/test/regress/expected/columnar_cache.out
@@ -3122,3 +3122,17 @@ SELECT SUM(value)
 
 COMMIT;
 DROP TABLE test_2;
+CREATE TABLE t1 (i int) USING columnar;
+INSERT INTO t1 SELECT generate_series(1, 1000000, 1);
+EXPLAIN SELECT COUNT(*) FROM t1;
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Finalize Aggregate  (cost=1472.17..1472.18 rows=1 width=8)
+   ->  Gather  (cost=1471.54..1472.15 rows=6 width=8)
+         Workers Planned: 6
+         ->  Partial Aggregate  (cost=471.54..471.55 rows=1 width=8)
+               ->  Parallel Custom Scan (ColumnarScan) on t1  (cost=0.00..54.88 rows=166667 width=0)
+                     Columnar Projected Columns: <columnar optimized out all columns>
+(6 rows)
+
+DROP TABLE t1;

--- a/columnar/src/test/regress/sql/columnar_cache.sql
+++ b/columnar/src/test/regress/sql/columnar_cache.sql
@@ -109,3 +109,8 @@ COMMIT;
 
 DROP TABLE test_2;
 
+CREATE TABLE t1 (i int) USING columnar;
+
+INSERT INTO t1 SELECT generate_series(1, 1000000, 1);
+EXPLAIN SELECT COUNT(*) FROM t1;
+DROP TABLE t1;


### PR DESCRIPTION
While the `head` of the cache linked list should be created when a query is run, when a simple explain is run without running the query, the `head` is not initialized.

In addition, once it is initialized, it is not being set back to a full reset state of `NULL`. 

### What's changed?

A check is now made against `head` being `NULL` before attempting to iterate the linked list, and `head` is set to `NULL` again when a new memory context is created for the query.  Since `head` is allocated in the query context, and the context is destroyed, this should be a-ok.

fixes #124

also, backports a check against another linked list that fails in `assert` when asserts are enabled.
