### PR TITLE
Fix 'make install DESTDIR=..'

### DIFF
--- a/columnar/Makefile
+++ b/columnar/Makefile
@@ -21,6 +21,7 @@ install-extension: extension
 	$(MAKE) -C src/backend/columnar install
 
 install-headers: extension
+	@mkdir -p '$(DESTDIR)$(includedir_server)'
 	$(INSTALL_DATA) $(citus_top_builddir)/src/include/citus_version.h '$(DESTDIR)$(includedir_server)/'
 
 clean-extension:


### PR DESCRIPTION
The command:

	make install DESTDIR=/dst

Fails with:

	make[1]: Leaving directory '/src/columnar/src/backend/columnar'
	/usr/bin/install -c -m 644 ./src/include/citus_version.h '/dst/usr/include/postgresql/server/'
	install: can't create '/dst/usr/include/postgresql/server/': No such file or directory

I guess it assumes this directory already exists from a PostgreSQL installation, but when using DESTDIR it may not exist in there yet, so make sure the directory exists.

<!--
Thanks for opening a pull request to Hydra! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Please make sure your code changes are covered with tests.
- If your change affects functionality, please include an entry for your PR in CHANGELOG.md
- In the case of new features or big changes, please open a docs PR for the feature at our docs repo:
  https://github.com/hydradatabase/docs

Feel free to ping committers for the review!
-->

<!-- Include an overview here -->

### What's changed?

<!--
Describe in detail what you've changed.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->
