### PR TITLE
set `-c config_file=` in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,3 +10,4 @@ services:
     volumes:
       - ./volumes/db:/var/lib/postgresql/data
       - ./files/postgres/postgresql.conf:/etc/postgresql/postgresql.conf
+    command: postgres -c 'config_file=/etc/postgresql/postgresql.conf'


### PR DESCRIPTION
fixes #130

This is the recommendation per the docs ( https://hub.docker.com/_/postgres/ ) that I was following, but I missed that they had `-c 'config_file=...'`.