### PR TITLE
[columnar] Update index whitelist to include GIN and GIST

### DIFF
--- a/columnar/src/test/regress/expected/columnar_alter.out
+++ b/columnar/src/test/regress/expected/columnar_alter.out
@@ -414,12 +414,11 @@ BEGIN;
   ALTER TABLE products ADD COLUMN store_id text PRIMARY KEY;
 ERROR:  column "store_id" of relation "products" contains null values
 ROLLBACK;
--- Add an EXCLUSION constraint (should fail)
+-- Add an EXCLUSION constraint (should succeed)
 CREATE TABLE circles (
     c circle,
     EXCLUDE USING gist (c WITH &&)
 ) USING columnar;
-ERROR:  unsupported access method for the index on columnar table circles
 -- Row level security
 CREATE TABLE public.row_level_security_col (id int, pgUser CHARACTER VARYING) USING columnar;
 CREATE USER user1;

--- a/columnar/src/test/regress/expected/columnar_alter_set_type.out
+++ b/columnar/src/test/regress/expected/columnar_alter_set_type.out
@@ -63,7 +63,7 @@ SELECT columnar.alter_columnar_table_set('test', compression => 'lz4');
 INSERT INTO test VALUES(1);
 VACUUM VERBOSE test;
 INFO:  statistics for "test":
-storage id: 10000000136
+storage id: 10000000137
 total file size: 24576, total data size: 6
 compression rate: 0.83x
 total row count: 1, stripe count: 1, average rows per stripe: 1
@@ -72,7 +72,7 @@ chunk count: 1, containing data for dropped columns: 0, lz4 compressed: 1
 ALTER TABLE test ALTER COLUMN i TYPE int8;
 VACUUM VERBOSE test;
 INFO:  statistics for "test":
-storage id: 10000000137
+storage id: 10000000138
 total file size: 24576, total data size: 10
 compression rate: 0.90x
 total row count: 1, stripe count: 1, average rows per stripe: 1

--- a/columnar/src/test/regress/expected/columnar_alter_table_set_access_method.out
+++ b/columnar/src/test/regress/expected/columnar_alter_table_set_access_method.out
@@ -276,8 +276,6 @@ SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = 'tbl'::regc
 (4 rows)
 
 SELECT columnar.alter_table_set_access_method('tbl', 'columnar');
-WARNING:  Index `CREATE INDEX tbl_gin ON public.tbl USING gin (i)` cannot be created.
-WARNING:  Index `CREATE INDEX tbl_gist ON public.tbl USING gist (p)` cannot be created.
 WARNING:  Index `CREATE INDEX tbl_brin ON public.tbl USING brin (a) WITH (pages_per_range='1')` cannot be created.
  alter_table_set_access_method 
 -------------------------------
@@ -294,10 +292,12 @@ SELECT indexname FROM pg_indexes WHERE tablename = 'tbl' ORDER BY indexname;
   indexname   
 --------------
  tbl_a_p_excl
+ tbl_gin
+ tbl_gist
  tbl_hash
  tbl_pkey
  tbl_unique
-(4 rows)
+(6 rows)
 
 SELECT conname FROM pg_constraint
 WHERE conrelid = 'tbl'::regclass
@@ -326,10 +326,12 @@ SELECT indexname FROM pg_indexes WHERE tablename = 'tbl' ORDER BY indexname;
   indexname   
 --------------
  tbl_a_p_excl
+ tbl_gin
+ tbl_gist
  tbl_hash
  tbl_pkey
  tbl_unique
-(4 rows)
+(6 rows)
 
 SELECT conname FROM pg_constraint
 WHERE conrelid = 'tbl'::regclass

--- a/columnar/src/test/regress/expected/columnar_indexes.out
+++ b/columnar/src/test/regress/expected/columnar_indexes.out
@@ -372,19 +372,16 @@ SELECT b=980 FROM include_test WHERE a = 980;
 CREATE TABLE testjsonb (j JSONB) USING columnar;
 INSERT INTO testjsonb SELECT CAST('{"f1" : ' ||'"'|| i*4 ||'", ' || '"f2" : '||'"'|| i*10 ||'"}' AS JSON) FROM generate_series(1,10) i;
 CREATE INDEX jidx ON testjsonb USING GIN (j);
-ERROR:  unsupported access method for the index on columnar table testjsonb
 INSERT INTO testjsonb SELECT CAST('{"f1" : ' ||'"'|| i*4 ||'", ' || '"f2" : '||'"'|| i*10 ||'"}' AS JSON) FROM generate_series(15,20) i;
 -- gist --
 CREATE TABLE gist_point_tbl(id INT4, p POINT) USING columnar;
 INSERT INTO gist_point_tbl (id, p) SELECT g, point(g*10, g*10) FROM generate_series(1, 10) g;
 CREATE INDEX gist_pointidx ON gist_point_tbl USING gist(p);
-ERROR:  unsupported access method for the index on columnar table gist_point_tbl
 INSERT INTO gist_point_tbl (id, p) SELECT g, point(g*10, g*10) FROM generate_series(10, 20) g;
 -- sp gist --
 CREATE TABLE box_temp (f1 box) USING columnar;
 INSERT INTO box_temp SELECT box(point(i, i), point(i * 2, i * 2)) FROM generate_series(1, 10) AS i;
 CREATE INDEX CONCURRENTLY box_spgist ON box_temp USING spgist (f1);
-ERROR:  unsupported access method for the index on columnar table box_temp
 -- CONCURRENTLY should not leave an invalid index behind
 SELECT COUNT(*)=0 FROM pg_index WHERE indrelid = 'box_temp'::regclass AND indisvalid = 'false';
  ?column? 
@@ -396,7 +393,7 @@ INSERT INTO box_temp SELECT box(point(i, i), point(i * 2, i * 2)) FROM generate_
 -- brin --
 CREATE TABLE brin_summarize (value int) USING columnar;
 CREATE INDEX brin_summarize_idx ON brin_summarize USING brin (value) WITH (pages_per_range=2);
-ERROR:  unsupported access method for the index on columnar table brin_summarize
+ERROR:  unsupported access method for the index on columnar table brin_summarize (brin)
 -- Show that we safely fallback to serial index build.
 CREATE TABLE parallel_scan_test(a int) USING columnar WITH ( parallel_workers = 2 );
 INSERT INTO parallel_scan_test SELECT i FROM generate_series(1,10) i;
@@ -742,5 +739,63 @@ BEGIN;
   INSERT INTO index_tuple_delete SELECT i FROM generate_series(0,10000)i;
 ROLLBACK;
 COPY index_tuple_delete FROM PROGRAM 'seq 10000';
+-- gist exclusions
+CREATE TABLE circles (
+  c circle,
+  EXCLUDE USING gist (c WITH &&)
+);
+-- first should succeed
+INSERT INTO circles (c) VALUES (CIRCLE(POINT(1.2, 123.1), 10));
+-- second should fail
+INSERT INTO circles (c) VALUES (CIRCLE(POINT(1.2, 123.1), 10));
+ERROR:  conflicting key value violates exclusion constraint "circles_c_excl"
+DETAIL:  Key (c)=(<(1.2,123.1),10>) conflicts with existing key (c)=(<(1.2,123.1),10>).
+-- gist
+CREATE TABLE circles_and_stuff (
+  c circle,
+  label text
+) USING columnar;
+CREATE INDEX gist_1 ON circles_and_stuff USING GIST (c);
+INSERT INTO circles_and_stuff (c, label) VALUES (circle(point(4.2, 123.1), 10), 'hello');
+INSERT INTO circles_and_stuff (c, label) VALUES (circle(point(1.2, 123.1), 10), 'world');
+INSERT INTO circles_and_stuff (c, label) VALUES (circle(point(6.2, 123.1), 100), 'hello');
+BEGIN;
+  SET LOCAL columnar.enable_custom_scan TO 'OFF';
+  SELECT columnar_test_helpers.uses_index_scan (
+  $$
+  SELECT * FROM circles_and_stuff WHERE c && CIRCLE(POINT(1.2, 123.1), 10);
+  $$
+  );
+ uses_index_scan 
+-----------------
+ t
+(1 row)
+
+ROLLBACK;
+BEGIN;
+  SET LOCAL columnar.enable_custom_scan TO 'ON';
+  SET LOCAL enable_indexscan TO 'OFF';
+  SELECT columnar_test_helpers.uses_custom_scan (
+    $$
+    SELECT * FROM circles_and_stuff WHERE c && CIRCLE(POINT(1.2, 123.1), 10);
+    $$
+  );
+ uses_custom_scan 
+------------------
+ t
+(1 row)
+
+ROLLBACK;
+BEGIN;
+  SET LOCAL columnar.enable_custom_scan TO 'OFF';
+  SET LOCAL enable_indexscan TO 'ON';
+  DELETE FROM circles_and_stuff WHERE label = 'hello';
+  SELECT COUNT(*) FROM circles_and_stuff; -- should return 1
+ count 
+-------
+     1
+(1 row)
+
+ROLLBACK;
 SET client_min_messages TO WARNING;
 DROP SCHEMA columnar_indexes CASCADE;

--- a/columnar/src/test/regress/expected/columnar_paths.out
+++ b/columnar/src/test/regress/expected/columnar_paths.out
@@ -113,6 +113,7 @@ BEGIN;
 
 ROLLBACK;
 BEGIN;
+  SET LOCAL enable_indexscan TO 'OFF';
   TRUNCATE full_correlated;
   INSERT INTO full_correlated SELECT i, i::text FROM generate_series(1, 1000) i;
   -- Since we have much smaller number of rows, selectivity of below

--- a/columnar/src/test/regress/expected/columnar_paths_1.out
+++ b/columnar/src/test/regress/expected/columnar_paths_1.out
@@ -113,6 +113,7 @@ BEGIN;
 
 ROLLBACK;
 BEGIN;
+  SET LOCAL enable_indexscan TO 'OFF';
   TRUNCATE full_correlated;
   INSERT INTO full_correlated SELECT i, i::text FROM generate_series(1, 1000) i;
   -- Since we have much smaller number of rows, selectivity of below

--- a/columnar/src/test/regress/sql/columnar_alter.sql
+++ b/columnar/src/test/regress/sql/columnar_alter.sql
@@ -245,7 +245,7 @@ BEGIN;
   ALTER TABLE products ADD COLUMN store_id text PRIMARY KEY;
 ROLLBACK;
 
--- Add an EXCLUSION constraint (should fail)
+-- Add an EXCLUSION constraint (should succeed)
 CREATE TABLE circles (
     c circle,
     EXCLUDE USING gist (c WITH &&)

--- a/columnar/src/test/regress/sql/columnar_paths.sql
+++ b/columnar/src/test/regress/sql/columnar_paths.sql
@@ -76,6 +76,7 @@ BEGIN;
 ROLLBACK;
 
 BEGIN;
+  SET LOCAL enable_indexscan TO 'OFF';
   TRUNCATE full_correlated;
   INSERT INTO full_correlated SELECT i, i::text FROM generate_series(1, 1000) i;
 


### PR DESCRIPTION
This PR expands the whitelist for which indexes are allowed to be created against a columnar table.

This does not mean that these indexes will be automatically used, in fact in many cases the indexes will not be used.  This just allows for additional indexes to be created which can be used either by explicitly disabling `columnar.enable_custom_scan` or by using a plan modification such as `pg_plan_hint`.

Newly supported indexes:

* `gin`
* `gist` - also supports postgis indexes and pg_embedding indexes
* `spgist`
* `rum` - external `gin`-like index type

Not supported:

* `brin` - difficult to support due to how it is tied into the storage
* `bloom` - supportable, but unable to get the index to be used, so left off white list, might be worth a second look later

