### PR TITLE
[columnar] Cache eviction crash

### DIFF
--- a/columnar/src/backend/columnar/columnar_reader.c
+++ b/columnar/src/backend/columnar/columnar_reader.c
@@ -1831,6 +1831,11 @@ DeserializeChunkData(StripeBuffers *stripeBuffers, uint64 chunkIndex,
 				columnBuffers->chunkBuffersArray[chunkIndex];
 			bool shouldCache = columnar_enable_page_cache == true && chunkBuffers->valueCompressionType != COMPRESSION_NONE;
 
+			if (shouldCache)
+			{
+				ColumnarMarkChunkGroupInUse(state->relation->rd_id, stripeId, chunkIndex);
+			}
+
 			/* decompress and deserialize current chunk's data */
 			StringInfo valueBuffer = NULL;
 			

--- a/columnar/src/backend/columnar/columnar_tableam.c
+++ b/columnar/src/backend/columnar/columnar_tableam.c
@@ -526,6 +526,12 @@ columnar_index_fetch_end(IndexFetchTableData *sscan)
 		ColumnarEndRead(scan->cs_readState);
 		scan->cs_readState = NULL;
 	}
+
+	/* clean up any caches. */
+	if (columnar_enable_page_cache == true)
+	{
+		ColumnarResetCache();
+	}
 }
 
 

--- a/columnar/src/include/columnar/columnar.h
+++ b/columnar/src/include/columnar/columnar.h
@@ -435,6 +435,7 @@ extern void CleanupReadStateCache(SubTransactionId currentSubXid);
 extern MemoryContext GetColumnarReadStateCache(void);
 
 /* columnar_cache.c */
+extern void ColumnarMarkChunkGroupInUse(uint64 relId, uint64 stripeId, uint32 chunkId);
 extern void ColumnarAddCacheEntry(uint64, uint64, uint64, uint32, void *);
 extern void *ColumnarRetrieveCache(uint64, uint64, uint64, uint32);
 extern void ColumnarResetCache(void);


### PR DESCRIPTION
Cache can be evected if still is in use, so it can trigger random memory problems or crash running process.
Fixed by keeping track of current chunk that is in use so we don't consider it for eviction.

Changed current cache coding style to align with rest of code.