### PR TITLE
[columnar] Vectorized direct aggregates

### DIFF
--- a/columnar/src/backend/columnar/Makefile
+++ b/columnar/src/backend/columnar/Makefile
@@ -1,7 +1,7 @@
 citus_subdir = src/backend/columnar
 citus_top_builddir = ../../..
 safestringlib_srcdir = $(citus_abs_top_srcdir)/vendor/safestringlib
-SUBDIRS = . safeclib vectorization vectorization/types
+SUBDIRS = . safeclib vectorization vectorization/types vectorization/nodes 
 SUBDIRS +=
 ENSURE_SUBDIRS_EXIST := $(shell mkdir -p $(SUBDIRS))
 OBJS += \
@@ -9,6 +9,11 @@ OBJS += \
 
 MODULE_big = columnar
 PG_CPPFLAGS += -I$(libpq_srcdir) -I$(safestringlib_srcdir)/include
+
+ifdef COLUMNAR_O3
+PG_CFLAGS += -O3
+endif
+
 EXTENSION = columnar
 
 template_sql_files = $(patsubst $(citus_abs_srcdir)/%,%,$(wildcard $(citus_abs_srcdir)/sql/*.sql))

--- a/columnar/src/backend/columnar/columnar.c
+++ b/columnar/src/backend/columnar/columnar.c
@@ -37,6 +37,8 @@
 #define DEFAULT_COMPRESSION_TYPE COMPRESSION_PG_LZ
 #endif
 
+static void columnar_guc_init(void);
+
 int columnar_compression = DEFAULT_COMPRESSION_TYPE;
 int columnar_stripe_row_limit = DEFAULT_STRIPE_ROW_COUNT;
 int columnar_chunk_group_row_limit = DEFAULT_CHUNK_ROW_COUNT;
@@ -64,13 +66,14 @@ static const struct config_enum_entry columnar_compression_options[] =
 void
 columnar_init(void)
 {
-	columnar_init_gucs();
+	columnar_guc_init();
 	columnar_tableam_init();
+	columnar_planner_init();
 }
 
 
-void
-columnar_init_gucs()
+static void
+columnar_guc_init()
 {
 	DefineCustomEnumVariable("columnar.compression",
 							 "Compression type for columnar.",

--- a/columnar/src/backend/columnar/columnar.control
+++ b/columnar/src/backend/columnar/columnar.control
@@ -1,4 +1,4 @@
 comment = 'Hydra Columnar extension'
-default_version = '11.1-8'
+default_version = '11.1-9'
 module_pathname = '$libdir/columnar'
 relocatable = false

--- a/columnar/src/backend/columnar/columnar_planner_hook.c
+++ b/columnar/src/backend/columnar/columnar_planner_hook.c
@@ -1,0 +1,327 @@
+/*-------------------------------------------------------------------------
+ *
+ * columnar_planner_hook.c
+ *
+ * Copyright (c) Hydra, Inc.
+ *
+ * Modify top plan and change aggregate function to provided ones that can execute on 
+ * column vector.
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "postgres.h"
+
+#include "miscadmin.h"
+
+#include "access/amapi.h"
+#include "catalog/pg_aggregate.h"
+#include "catalog/pg_am.h"
+#include "catalog/pg_statistic.h"
+#include "catalog/pg_operator.h"
+#include "catalog/pg_proc.h"
+#include "commands/defrem.h"
+#include "optimizer/cost.h"
+#include "optimizer/optimizer.h"
+#include "optimizer/pathnode.h"
+#include "optimizer/paths.h"
+#include "optimizer/plancat.h"
+#include "optimizer/planner.h"
+#include "optimizer/restrictinfo.h"
+#include "tcop/utility.h"
+#include "parser/parse_oper.h"
+#include "parser/parse_func.h"
+#include "utils/builtins.h"
+#include "utils/lsyscache.h"
+#include "utils/selfuncs.h"
+#include "utils/syscache.h"
+#include "utils/spccache.h"
+
+#include "columnar/columnar.h"
+#include "columnar/columnar_customscan.h"
+#include "columnar/vectorization/columnar_vector_execution.h"
+#include "columnar/vectorization/nodes/columnar_aggregator_node.h"
+
+#include "columnar/utils/listutils.h"
+
+static planner_hook_type PreviousPlannerHook = NULL;
+
+static PlannedStmt * ColumnarPlannerHook(Query *parse,  const char *query_string,
+										 int cursorOptions, ParamListInfo boundParams);
+
+#if PG_VERSION_NUM >= PG_VERSION_14
+static Plan * PlanTreeMutator(Plan *node, void *context);
+
+typedef struct PlanTreeMutatorContext
+{
+	bool vectorizedAggregation;
+} PlanTreeMutatorContext;
+
+
+#define FLATCOPY(newnode, node, nodetype)  \
+	( (newnode) = (nodetype *) palloc(sizeof(nodetype)), \
+	  memcpy((newnode), (node), sizeof(nodetype)) )
+
+static Node *
+AggRefArgsExpressionMutator(Node *node, void *context)
+{
+	if (node == NULL)
+		return false;
+
+	Node *previousNode = (Node *) context;
+
+	if (IsA(node, OpExpr) || IsA(node, DistinctExpr) || IsA(node, NullIfExpr) )
+	{
+		OpExpr *opExprNode = (OpExpr *) node;
+
+		Form_pg_operator operatorForm;
+		HeapTuple operatorTuple;
+
+		if (list_length(opExprNode->args) != 2)
+		{
+			elog(ERROR, "Aggregation vectorizaion works only on two arguments.");
+			return false;
+		}
+
+		if (CheckOpExprArgumentRules(opExprNode->args))
+		{
+			elog(ERROR, "Unsupported aggregate argument combination.");
+			return false;
+		}
+
+		operatorTuple = SearchSysCache1(OPEROID, ObjectIdGetDatum(opExprNode->opno));
+		operatorForm = (Form_pg_operator) GETSTRUCT(operatorTuple);
+		Oid procedureOid = operatorForm->oprcode;
+		ReleaseSysCache(operatorTuple);
+
+		Oid vectorizedProcedureOid;
+		if (!GetVectorizedProcedureOid(procedureOid, &vectorizedProcedureOid))
+		{
+			elog(ERROR, "Vectorized aggregate not found.");
+		}
+
+		opExprNode->opfuncid = vectorizedProcedureOid;
+
+		return (Node *) opExprNode;
+	}
+
+	/* This should handle aggregates that use only const as argument */
+	if (previousNode != NULL && IsA(previousNode, TargetEntry) && IsA(node, Const))
+	{
+		elog(ERROR, "Vectorized Aggregates accepts only non-const values.");
+		return false;
+	}
+
+	return expression_tree_mutator(node, AggRefArgsExpressionMutator, (void *) node);
+}
+
+static Node *
+ExpressionMutator(Node *node, void *context)
+{
+	if (node == NULL)
+		return false;
+
+	if (IsA(node, Aggref))
+	{
+		Aggref *oldAggRefNode = (Aggref *) node;
+		Aggref *newAggRefNode = copyObject(oldAggRefNode);
+
+		if (oldAggRefNode->aggdistinct)
+		{
+			elog(ERROR, "Vectorized aggregate with DISTINCT not supported.");
+		}
+
+		newAggRefNode->args = (List *)
+			expression_tree_mutator((Node *) oldAggRefNode->args, AggRefArgsExpressionMutator, NULL);
+		
+		Oid vectorizedProcedureOid = 0;
+		if (!GetVectorizedProcedureOid(newAggRefNode->aggfnoid, &vectorizedProcedureOid))
+		{
+			elog(ERROR, "Vectorized aggregate not found.");
+		}
+
+		newAggRefNode->aggfnoid = vectorizedProcedureOid;
+
+		return (Node *) newAggRefNode;
+	}
+
+	return expression_tree_mutator(node, ExpressionMutator, (void *) context);
+}
+
+
+static Plan *
+PlanTreeMutator(Plan *node, void *context)
+{
+	if (node == NULL)
+		return NULL;
+
+	/* Guard against stack overflow due to overly complex expressions */
+	check_stack_depth();
+
+	switch (nodeTag(node))
+	{
+		case T_CustomScan:
+		{
+			CustomScan *customScan = (CustomScan *) node;
+
+			if (customScan->methods == columnar_customscan_methods())
+			{
+				PlanTreeMutatorContext *planTreeContext = (PlanTreeMutatorContext *) context;
+
+				Const * vectorizedAggregateExecution = makeNode(Const);
+
+				vectorizedAggregateExecution->constbyval = true;
+				vectorizedAggregateExecution->consttype = CUSTOM_SCAN_VECTORIZED_AGGREGATE;
+				vectorizedAggregateExecution->constvalue =  planTreeContext->vectorizedAggregation;
+				vectorizedAggregateExecution->constlen = sizeof(bool);
+
+				customScan->custom_private = lappend(customScan->custom_private, vectorizedAggregateExecution);
+			}
+
+			break;
+		}
+
+		case T_Agg:
+		{
+			Agg *aggNode = (Agg *) node;
+			Agg	*newAgg;
+			CustomScan *vectorizedAggNode;
+
+			if (aggNode->plan.lefttree->type == T_CustomScan)
+			{
+				if (aggNode->aggstrategy == AGG_PLAIN)
+				{
+					vectorizedAggNode = columnar_create_aggregator_node();
+
+					FLATCOPY(newAgg, aggNode, Agg);
+
+					newAgg->plan.targetlist = 
+						(List *) expression_tree_mutator((Node *) newAgg->plan.targetlist, ExpressionMutator, NULL);
+
+
+					vectorizedAggNode->custom_plans = 
+						lappend(vectorizedAggNode->custom_plans, newAgg);
+					vectorizedAggNode->scan.plan.targetlist = 
+						CustomBuildTargetList(aggNode->plan.targetlist, INDEX_VAR);
+					vectorizedAggNode->custom_scan_tlist = newAgg->plan.targetlist;
+
+					// Parallel agg node
+					Plan *vectorizedAggNodePlan = (Plan *) vectorizedAggNode;
+					vectorizedAggNodePlan->parallel_aware = aggNode->plan.lefttree->parallel_aware;
+					vectorizedAggNodePlan->startup_cost = aggNode->plan.startup_cost;
+					vectorizedAggNodePlan->total_cost = aggNode->plan.total_cost;
+					vectorizedAggNodePlan->plan_rows = aggNode->plan.plan_rows;
+					vectorizedAggNodePlan->plan_width = aggNode->plan.plan_width;
+
+
+					PlanTreeMutatorContext *planTreeContext = (PlanTreeMutatorContext *) context;
+					planTreeContext->vectorizedAggregation = true;
+
+					PlanTreeMutator(node->lefttree, context);
+					PlanTreeMutator(node->righttree, context);
+
+					vectorizedAggNode->scan.plan.lefttree = node->lefttree;
+					vectorizedAggNode->scan.plan.righttree = node->righttree;
+
+					return (Plan *) vectorizedAggNode;
+				}
+
+				return node;
+			}
+
+			break;
+		}
+		default:
+		{
+			
+			break;
+		}
+	}
+
+	node->lefttree = PlanTreeMutator(node->lefttree, context);
+	node->righttree = PlanTreeMutator(node->righttree, context);
+
+	return node;
+}
+#endif
+
+static PlannedStmt *
+ColumnarPlannerHook(Query *parse,
+					const char *query_string,
+					int cursorOptions,
+					ParamListInfo boundParams)
+{
+	PlannedStmt	*stmt;
+#if PG_VERSION_NUM >= PG_VERSION_14
+	Plan *savedPlanTree;
+	List *savedSubplan;
+	MemoryContext saved_context;
+#endif
+
+	if (PreviousPlannerHook)
+		stmt = PreviousPlannerHook(parse, query_string, cursorOptions, boundParams);
+	else
+		stmt = standard_planner(parse, query_string, cursorOptions, boundParams);
+
+#if PG_VERSION_NUM >= PG_VERSION_14
+	if (!columnar_enable_vectorization			/* Vectorization should be enabled */
+		|| stmt->commandType != CMD_SELECT		 /* only SELECTS are supported  */
+		|| list_length(stmt->rtable) != 1)		 /* JOINs are not yet supported */
+		return stmt;
+
+
+	savedPlanTree = stmt->planTree;
+	savedSubplan = stmt->subplans;
+
+	saved_context = CurrentMemoryContext;
+
+	PG_TRY();
+	{
+		List		*subplans = NULL;
+		ListCell	*cell;
+
+		PlanTreeMutatorContext plainTreeContext;
+		plainTreeContext.vectorizedAggregation = 0;
+
+		stmt->planTree = (Plan *) PlanTreeMutator(stmt->planTree, (void *) &plainTreeContext);
+
+		foreach(cell, stmt->subplans)
+		{
+			PlanTreeMutatorContext subPlainTreeContext;
+			plainTreeContext.vectorizedAggregation = 0;
+			Plan *subplan = (Plan *) PlanTreeMutator(lfirst(cell), (void *) &subPlainTreeContext);
+			subplans = lappend(subplans, subplan);
+		}
+
+		stmt->subplans = subplans;
+	}
+	PG_CATCH();
+	{
+		ErrorData  *edata;
+		MemoryContextSwitchTo(saved_context);
+
+		edata = CopyErrorData();
+		FlushErrorState();
+		ereport(DEBUG1,
+				(errcode(ERRCODE_INTERNAL_ERROR),
+					errmsg("Query can't be vectorized. Falling back to original execution."),
+					errdetail("%s", edata->message)));
+		stmt->planTree = savedPlanTree;
+		stmt->subplans = savedSubplan;
+	}
+
+	PG_END_TRY();
+#endif
+
+	return stmt;
+}
+
+
+void columnar_planner_init(void)
+{
+	PreviousPlannerHook = planner_hook;
+	planner_hook = ColumnarPlannerHook;
+#if  PG_VERSION_NUM >= PG_VERSION_14
+	columnar_register_aggregator_node();
+#endif
+}

--- a/columnar/src/backend/columnar/columnar_reader.c
+++ b/columnar/src/backend/columnar/columnar_reader.c
@@ -2066,7 +2066,7 @@ ReadStripeNextVector(StripeReadState *stripeReadState, Datum *columnValues,
 				continue;
 		}
 
-		stripeReadState->currentRow += *newVectorSize;
+		stripeReadState->currentRow += stripeReadState->chunkGroupReadState->rowCount;
 
 		return true;
 	}
@@ -2111,7 +2111,6 @@ ReadChunkGroupNextVector(ChunkGroupReadState *chunkGroupReadState, Datum *column
 
 			if (checkLookupMask & checkColumnMask)
 			{
-				(*chunkReadRows)++;
 				chunkGroupReadState->currentRow++;
 				continue;
 			}

--- a/columnar/src/backend/columnar/columnar_tableam.c
+++ b/columnar/src/backend/columnar/columnar_tableam.c
@@ -385,7 +385,7 @@ columnar_getnextslot(TableScanDesc sscan, ScanDirection direction, TupleTableSlo
 
 		vectorTTS->dimension = newVectorSize;
 
-		memset(vectorTTS->skip, 0, newVectorSize);
+		memset(vectorTTS->keep, true, newVectorSize);
 
 		ExecStoreVirtualTuple(slot);
 	}
@@ -1219,6 +1219,9 @@ TruncateAndCombineColumnarStripes(Relation rel, int elevel)
 		startingStripeListPosition++;
 	}
 
+	/*
+	 * One stripe that is "full" so do nothing.
+	 */
 	if (startingStripeListPosition == 0)
 	{
 		return false;
@@ -1228,7 +1231,7 @@ TruncateAndCombineColumnarStripes(Relation rel, int elevel)
 	 * There is only one stripe that is candidate. Maybe we should vacuum
 	 * it if condition is met.
 	 */
-	if (startingStripeListPosition == 1)
+	else if (startingStripeListPosition == 1)
 	{
 		/* Maybe we should vacuum only one stripe if count of
 		 * deleted rows is higher than 20 percent.

--- a/columnar/src/backend/columnar/sql/columnar--11.1-8--11.1-9.sql
+++ b/columnar/src/backend/columnar/sql/columnar--11.1-8--11.1-9.sql
@@ -1,0 +1,68 @@
+-- columnar--11.1-8--11.1-9.sql
+
+-- count
+
+CREATE FUNCTION vemptycount(int8) RETURNS int8 AS 'MODULE_PATHNAME' LANGUAGE C IMMUTABLE;
+CREATE FUNCTION vanycount(int8, "any") RETURNS int8 AS 'MODULE_PATHNAME' LANGUAGE C IMMUTABLE;
+
+CREATE AGGREGATE vcount(*) (SFUNC = vemptycount, STYPE = int8, INITCOND="0");
+CREATE AGGREGATE vcount("any") (SFUNC = vanycount, STYPE = int8, INITCOND="0");
+
+-- int2 / int4
+
+CREATE FUNCTION vint2int4avg(internal) RETURNS numeric AS 'MODULE_PATHNAME' LANGUAGE C IMMUTABLE;
+
+-- int2
+
+CREATE FUNCTION vint2sum(int8, int2) RETURNS int8 AS 'MODULE_PATHNAME' LANGUAGE C IMMUTABLE;
+CREATE AGGREGATE vsum(int2) (SFUNC = vint2sum, STYPE = int8, INITCOND="0");
+
+CREATE FUNCTION vint2acc(internal, int2) RETURNS internal AS 'MODULE_PATHNAME' LANGUAGE C IMMUTABLE;
+CREATE AGGREGATE vavg(int2) (SFUNC = vint2acc, STYPE = internal, FINALFUNC = vint2int4avg, INITCOND = '{0,0}');
+
+CREATE FUNCTION vint2larger(int2, int2) RETURNS int2 AS 'MODULE_PATHNAME' LANGUAGE C IMMUTABLE;
+CREATE AGGREGATE vmax(int2) (SFUNC = vint2larger, STYPE = int2, INITCOND="-32768");
+
+CREATE FUNCTION vint2smaller(int2, int2) RETURNS int2 AS 'MODULE_PATHNAME' LANGUAGE C IMMUTABLE;
+CREATE AGGREGATE vmin(int2) (SFUNC = vint2smaller, STYPE = int2, INITCOND="32767");
+
+-- int4
+
+CREATE FUNCTION vint4sum(int8, int4) RETURNS int8 AS 'MODULE_PATHNAME' LANGUAGE C IMMUTABLE;
+CREATE AGGREGATE vsum(int4) (SFUNC = vint4sum, STYPE = int8, INITCOND="0");
+
+CREATE FUNCTION vint4acc(internal, int4) RETURNS internal AS 'MODULE_PATHNAME' LANGUAGE C IMMUTABLE;
+CREATE AGGREGATE vavg(int4) (SFUNC = vint4acc, STYPE = internal, FINALFUNC = vint2int4avg, INITCOND = '{0,0}');
+
+CREATE FUNCTION vint4larger(int4, int4) RETURNS int4 AS 'MODULE_PATHNAME' LANGUAGE C IMMUTABLE;
+CREATE AGGREGATE vmax(int4) (SFUNC = vint4larger, STYPE = int4, INITCOND="-2147483648");
+
+CREATE FUNCTION vint4smaller(int4, int4) RETURNS int4 AS 'MODULE_PATHNAME' LANGUAGE C IMMUTABLE;
+CREATE AGGREGATE vmin(int4) (SFUNC = vint4smaller, STYPE = int4, INITCOND="2147483647");
+
+
+-- int8
+
+CREATE FUNCTION vint8acc(internal, int8) RETURNS internal AS 'MODULE_PATHNAME' LANGUAGE C IMMUTABLE;
+
+CREATE FUNCTION vint8sum(internal) RETURNS numeric AS 'MODULE_PATHNAME' LANGUAGE C IMMUTABLE;
+CREATE AGGREGATE vsum(int8) (SFUNC = vint8acc, STYPE = internal, FINALFUNC = vint8sum, 
+                             SERIALFUNC = int8_avg_serialize, DESERIALFUNC = int8_avg_deserialize);
+
+CREATE FUNCTION vint8avg(internal) RETURNS numeric AS 'MODULE_PATHNAME' LANGUAGE C IMMUTABLE;
+CREATE AGGREGATE vavg(int8) (SFUNC = vint8acc, STYPE = internal, FINALFUNC = vint8avg, 
+                             SERIALFUNC = int8_avg_serialize, DESERIALFUNC = int8_avg_deserialize);
+
+CREATE FUNCTION vint8larger(int8, int8) RETURNS int8 AS 'MODULE_PATHNAME' LANGUAGE C IMMUTABLE;
+CREATE AGGREGATE vmax(int8) (SFUNC = vint8larger, STYPE = int8, INITCOND="-9223372036854775808");
+
+CREATE FUNCTION vint8smaller(int8, int8) RETURNS int8 AS 'MODULE_PATHNAME' LANGUAGE C IMMUTABLE;
+CREATE AGGREGATE vmin(int8) (SFUNC = vint8smaller, STYPE = int8, INITCOND="9223372036854775807");
+
+-- date
+
+CREATE FUNCTION vdatelarger(date, date) RETURNS date AS 'MODULE_PATHNAME' LANGUAGE C IMMUTABLE;
+CREATE AGGREGATE vmax(date) (SFUNC = vdatelarger, STYPE = date, INITCOND="-infinity");
+
+CREATE FUNCTION vdatesmaller(date, date) RETURNS date AS 'MODULE_PATHNAME' LANGUAGE C IMMUTABLE;
+CREATE AGGREGATE vmin(date) (SFUNC = vdatesmaller, STYPE = date, INITCOND="infinity");

--- a/columnar/src/backend/columnar/vectorization/nodes/columnar_aggregator_node.c
+++ b/columnar/src/backend/columnar/vectorization/nodes/columnar_aggregator_node.c
@@ -1,0 +1,5286 @@
+#include "postgres.h"
+#include "pg_version_constants.h"
+
+#if PG_VERSION_NUM >= PG_VERSION_14
+
+/*-------------------------------------------------------------------------
+ *
+ * nodeAgg.c
+ *	  Routines to handle aggregate nodes.
+ *
+ *	  ExecAgg normally evaluates each aggregate in the following steps:
+ *
+ *		 transvalue = initcond
+ *		 foreach input_tuple do
+ *			transvalue = transfunc(transvalue, input_value(s))
+ *		 result = finalfunc(transvalue, direct_argument(s))
+ *
+ *	  If a finalfunc is not supplied then the result is just the ending
+ *	  value of transvalue.
+ *
+ *	  Other behaviors can be selected by the "aggsplit" mode, which exists
+ *	  to support partial aggregation.  It is possible to:
+ *	  * Skip running the finalfunc, so that the output is always the
+ *	  final transvalue state.
+ *	  * Substitute the combinefunc for the transfunc, so that transvalue
+ *	  states (propagated up from a child partial-aggregation step) are merged
+ *	  rather than processing raw input rows.  (The statements below about
+ *	  the transfunc apply equally to the combinefunc, when it's selected.)
+ *	  * Apply the serializefunc to the output values (this only makes sense
+ *	  when skipping the finalfunc, since the serializefunc works on the
+ *	  transvalue data type).
+ *	  * Apply the deserializefunc to the input values (this only makes sense
+ *	  when using the combinefunc, for similar reasons).
+ *	  It is the planner's responsibility to connect up Agg nodes using these
+ *	  alternate behaviors in a way that makes sense, with partial aggregation
+ *	  results being fed to nodes that expect them.
+ *
+ *	  If a normal aggregate call specifies DISTINCT or ORDER BY, we sort the
+ *	  input tuples and eliminate duplicates (if required) before performing
+ *	  the above-depicted process.  (However, we don't do that for ordered-set
+ *	  aggregates; their "ORDER BY" inputs are ordinary aggregate arguments
+ *	  so far as this module is concerned.)	Note that partial aggregation
+ *	  is not supported in these cases, since we couldn't ensure global
+ *	  ordering or distinctness of the inputs.
+ *
+ *	  If transfunc is marked "strict" in pg_proc and initcond is NULL,
+ *	  then the first non-NULL input_value is assigned directly to transvalue,
+ *	  and transfunc isn't applied until the second non-NULL input_value.
+ *	  The agg's first input type and transtype must be the same in this case!
+ *
+ *	  If transfunc is marked "strict" then NULL input_values are skipped,
+ *	  keeping the previous transvalue.  If transfunc is not strict then it
+ *	  is called for every input tuple and must deal with NULL initcond
+ *	  or NULL input_values for itself.
+ *
+ *	  If finalfunc is marked "strict" then it is not called when the
+ *	  ending transvalue is NULL, instead a NULL result is created
+ *	  automatically (this is just the usual handling of strict functions,
+ *	  of course).  A non-strict finalfunc can make its own choice of
+ *	  what to return for a NULL ending transvalue.
+ *
+ *	  Ordered-set aggregates are treated specially in one other way: we
+ *	  evaluate any "direct" arguments and pass them to the finalfunc along
+ *	  with the transition value.
+ *
+ *	  A finalfunc can have additional arguments beyond the transvalue and
+ *	  any "direct" arguments, corresponding to the input arguments of the
+ *	  aggregate.  These are always just passed as NULL.  Such arguments may be
+ *	  needed to allow resolution of a polymorphic aggregate's result type.
+ *
+ *	  We compute aggregate input expressions and run the transition functions
+ *	  in a temporary econtext (aggstate->tmpcontext).  This is reset at least
+ *	  once per input tuple, so when the transvalue datatype is
+ *	  pass-by-reference, we have to be careful to copy it into a longer-lived
+ *	  memory context, and free the prior value to avoid memory leakage.  We
+ *	  store transvalues in another set of econtexts, aggstate->aggcontexts
+ *	  (one per grouping set, see below), which are also used for the hashtable
+ *	  structures in AGG_HASHED mode.  These econtexts are rescanned, not just
+ *	  reset, at group boundaries so that aggregate transition functions can
+ *	  register shutdown callbacks via AggRegisterCallback.
+ *
+ *	  The node's regular econtext (aggstate->ss.ps.ps_ExprContext) is used to
+ *	  run finalize functions and compute the output tuple; this context can be
+ *	  reset once per output tuple.
+ *
+ *	  The executor's AggState node is passed as the fmgr "context" value in
+ *	  all transfunc and finalfunc calls.  It is not recommended that the
+ *	  transition functions look at the AggState node directly, but they can
+ *	  use AggCheckCallContext() to verify that they are being called by
+ *	  nodeAgg.c (and not as ordinary SQL functions).  The main reason a
+ *	  transition function might want to know this is so that it can avoid
+ *	  palloc'ing a fixed-size pass-by-ref transition value on every call:
+ *	  it can instead just scribble on and return its left input.  Ordinarily
+ *	  it is completely forbidden for functions to modify pass-by-ref inputs,
+ *	  but in the aggregate case we know the left input is either the initial
+ *	  transition value or a previous function result, and in either case its
+ *	  value need not be preserved.  See int8inc() for an example.  Notice that
+ *	  the EEOP_AGG_PLAIN_TRANS step is coded to avoid a data copy step when
+ *	  the previous transition value pointer is returned.  It is also possible
+ *	  to avoid repeated data copying when the transition value is an expanded
+ *	  object: to do that, the transition function must take care to return
+ *	  an expanded object that is in a child context of the memory context
+ *	  returned by AggCheckCallContext().  Also, some transition functions want
+ *	  to store working state in addition to the nominal transition value; they
+ *	  can use the memory context returned by AggCheckCallContext() to do that.
+ *
+ *	  Note: AggCheckCallContext() is available as of PostgreSQL 9.0.  The
+ *	  AggState is available as context in earlier releases (back to 8.1),
+ *	  but direct examination of the node is needed to use it before 9.0.
+ *
+ *	  As of 9.4, aggregate transition functions can also use AggGetAggref()
+ *	  to get hold of the Aggref expression node for their aggregate call.
+ *	  This is mainly intended for ordered-set aggregates, which are not
+ *	  supported as window functions.  (A regular aggregate function would
+ *	  need some fallback logic to use this, since there's no Aggref node
+ *	  for a window function.)
+ *
+ *	  Grouping sets:
+ *
+ *	  A list of grouping sets which is structurally equivalent to a ROLLUP
+ *	  clause (e.g. (a,b,c), (a,b), (a)) can be processed in a single pass over
+ *	  ordered data.  We do this by keeping a separate set of transition values
+ *	  for each grouping set being concurrently processed; for each input tuple
+ *	  we update them all, and on group boundaries we reset those states
+ *	  (starting at the front of the list) whose grouping values have changed
+ *	  (the list of grouping sets is ordered from most specific to least
+ *	  specific).
+ *
+ *	  Where more complex grouping sets are used, we break them down into
+ *	  "phases", where each phase has a different sort order (except phase 0
+ *	  which is reserved for hashing).  During each phase but the last, the
+ *	  input tuples are additionally stored in a tuplesort which is keyed to the
+ *	  next phase's sort order; during each phase but the first, the input
+ *	  tuples are drawn from the previously sorted data.  (The sorting of the
+ *	  data for the first phase is handled by the planner, as it might be
+ *	  satisfied by underlying nodes.)
+ *
+ *	  Hashing can be mixed with sorted grouping.  To do this, we have an
+ *	  AGG_MIXED strategy that populates the hashtables during the first sorted
+ *	  phase, and switches to reading them out after completing all sort phases.
+ *	  We can also support AGG_HASHED with multiple hash tables and no sorting
+ *	  at all.
+ *
+ *	  From the perspective of aggregate transition and final functions, the
+ *	  only issue regarding grouping sets is this: a single call site (flinfo)
+ *	  of an aggregate function may be used for updating several different
+ *	  transition values in turn. So the function must not cache in the flinfo
+ *	  anything which logically belongs as part of the transition value (most
+ *	  importantly, the memory context in which the transition value exists).
+ *	  The support API functions (AggCheckCallContext, AggRegisterCallback) are
+ *	  sensitive to the grouping set for which the aggregate function is
+ *	  currently being called.
+ *
+ *	  Plan structure:
+ *
+ *	  What we get from the planner is actually one "real" Agg node which is
+ *	  part of the plan tree proper, but which optionally has an additional list
+ *	  of Agg nodes hung off the side via the "chain" field.  This is because an
+ *	  Agg node happens to be a convenient representation of all the data we
+ *	  need for grouping sets.
+ *
+ *	  For many purposes, we treat the "real" node as if it were just the first
+ *	  node in the chain.  The chain must be ordered such that hashed entries
+ *	  come before sorted/plain entries; the real node is marked AGG_MIXED if
+ *	  there are both types present (in which case the real node describes one
+ *	  of the hashed groupings, other AGG_HASHED nodes may optionally follow in
+ *	  the chain, followed in turn by AGG_SORTED or (one) AGG_PLAIN node).  If
+ *	  the real node is marked AGG_HASHED or AGG_SORTED, then all the chained
+ *	  nodes must be of the same type; if it is AGG_PLAIN, there can be no
+ *	  chained nodes.
+ *
+ *	  We collect all hashed nodes into a single "phase", numbered 0, and create
+ *	  a sorted phase (numbered 1..n) for each AGG_SORTED or AGG_PLAIN node.
+ *	  Phase 0 is allocated even if there are no hashes, but remains unused in
+ *	  that case.
+ *
+ *	  AGG_HASHED nodes actually refer to only a single grouping set each,
+ *	  because for each hashed grouping we need a separate grpColIdx and
+ *	  numGroups estimate.  AGG_SORTED nodes represent a "rollup", a list of
+ *	  grouping sets that share a sort order.  Each AGG_SORTED node other than
+ *	  the first one has an associated Sort node which describes the sort order
+ *	  to be used; the first sorted node takes its input from the outer subtree,
+ *	  which the planner has already arranged to provide ordered data.
+ *
+ *	  Memory and ExprContext usage:
+ *
+ *	  Because we're accumulating aggregate values across input rows, we need to
+ *	  use more memory contexts than just simple input/output tuple contexts.
+ *	  In fact, for a rollup, we need a separate context for each grouping set
+ *	  so that we can reset the inner (finer-grained) aggregates on their group
+ *	  boundaries while continuing to accumulate values for outer
+ *	  (coarser-grained) groupings.  On top of this, we might be simultaneously
+ *	  populating hashtables; however, we only need one context for all the
+ *	  hashtables.
+ *
+ *	  So we create an array, aggcontexts, with an ExprContext for each grouping
+ *	  set in the largest rollup that we're going to process, and use the
+ *	  per-tuple memory context of those ExprContexts to store the aggregate
+ *	  transition values.  hashcontext is the single context created to support
+ *	  all hash tables.
+ *
+ *	  Spilling To Disk
+ *
+ *	  When performing hash aggregation, if the hash table memory exceeds the
+ *	  limit (see hash_agg_check_limits()), we enter "spill mode". In spill
+ *	  mode, we advance the transition states only for groups already in the
+ *	  hash table. For tuples that would need to create a new hash table
+ *	  entries (and initialize new transition states), we instead spill them to
+ *	  disk to be processed later. The tuples are spilled in a partitioned
+ *	  manner, so that subsequent batches are smaller and less likely to exceed
+ *	  hash_mem (if a batch does exceed hash_mem, it must be spilled
+ *	  recursively).
+ *
+ *	  Spilled data is written to logical tapes. These provide better control
+ *	  over memory usage, disk space, and the number of files than if we were
+#if PG_VERSION_NUM < PG_VERSION_15
+ *	  to use a BufFile for each spill.
+#else
+ *	  to use a BufFile for each spill.  We don't know the number of tapes needed
+ *	  at the start of the algorithm (because it can recurse), so a tape set is
+ *	  allocated at the beginning, and individual tapes are created as needed.
+ *	  As a particular tape is read, logtape.c recycles its disk space. When a
+ *	  tape is read to completion, it is destroyed entirely.
+ *
+ *	  Tapes' buffers can take up substantial memory when many tapes are open at
+ *	  once. We only need one tape open at a time in read mode (using a buffer
+ *	  that's a multiple of BLCKSZ); but we need one tape open in write mode (each
+ *	  requiring a buffer of size BLCKSZ) for each partition.
+#endif
+ *
+ *	  Note that it's possible for transition states to start small but then
+ *	  grow very large; for instance in the case of ARRAY_AGG. In such cases,
+ *	  it's still possible to significantly exceed hash_mem. We try to avoid
+ *	  this situation by estimating what will fit in the available memory, and
+ *	  imposing a limit on the number of groups separately from the amount of
+ *	  memory consumed.
+ *
+ *    Transition / Combine function invocation:
+ *
+ *    For performance reasons transition functions, including combine
+ *    functions, aren't invoked one-by-one from nodeAgg.c after computing
+ *    arguments using the expression evaluation engine. Instead
+ *    ExecBuildAggTrans() builds one large expression that does both argument
+ *    evaluation and transition function invocation. That avoids performance
+ *    issues due to repeated uses of expression evaluation, complications due
+ *    to filter expressions having to be evaluated early, and allows to JIT
+ *    the entire expression into one native function.
+ *
+#if PG_VERSION_NUM < PG_VERSION_15
+ * Portions Copyright (c) 1996-2021, PostgreSQL Global Development Group
+#else
+ * Portions Copyright (c) 1996-2022, PostgreSQL Global Development Group
+#endif
+ * Portions Copyright (c) 1994, Regents of the University of California
+ *
+ * IDENTIFICATION
+ *	  src/backend/executor/nodeAgg.c
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "access/htup_details.h"
+#include "access/parallel.h"
+#include "catalog/objectaccess.h"
+#include "catalog/pg_aggregate.h"
+#include "catalog/pg_proc.h"
+#include "catalog/pg_type.h"
+#include "common/hashfn.h"
+#include "executor/execExpr.h"
+#include "executor/executor.h"
+#include "executor/nodeAgg.h"
+#include "lib/hyperloglog.h"
+#include "miscadmin.h"
+#include "nodes/makefuncs.h"
+#include "nodes/nodeFuncs.h"
+#include "optimizer/optimizer.h"
+#include "parser/parse_agg.h"
+#include "parser/parse_coerce.h"
+#include "utils/acl.h"
+#include "utils/builtins.h"
+#include "utils/datum.h"
+#include "utils/dynahash.h"
+#include "utils/expandeddatum.h"
+#include "utils/logtape.h"
+#include "utils/lsyscache.h"
+#include "utils/memutils.h"
+#include "utils/syscache.h"
+#include "utils/tuplesort.h"
+
+#include "columnar/vectorization/columnar_vector_types.h"
+#include "columnar/vectorization/columnar_vector_execution.h"
+#include "columnar/vectorization/nodes/columnar_aggregator_node.h"
+
+/*
+ * Control how many partitions are created when spilling HashAgg to
+ * disk.
+ *
+ * HASHAGG_PARTITION_FACTOR is multiplied by the estimated number of
+ * partitions needed such that each partition will fit in memory. The factor
+ * is set higher than one because there's not a high cost to having a few too
+ * many partitions, and it makes it less likely that a partition will need to
+ * be spilled recursively. Another benefit of having more, smaller partitions
+ * is that small hash tables may perform better than large ones due to memory
+ * caching effects.
+ *
+ * We also specify a min and max number of partitions per spill. Too few might
+ * mean a lot of wasted I/O from repeated spilling of the same tuples. Too
+ * many will result in lots of memory wasted buffering the spill files (which
+ * could instead be spent on a larger hash table).
+ */
+#define HASHAGG_PARTITION_FACTOR 1.50
+#define HASHAGG_MIN_PARTITIONS 4
+#define HASHAGG_MAX_PARTITIONS 1024
+
+/*
+ * For reading from tapes, the buffer size must be a multiple of
+ * BLCKSZ. Larger values help when reading from multiple tapes concurrently,
+ * but that doesn't happen in HashAgg, so we simply use BLCKSZ. Writing to a
+ * tape always uses a buffer of size BLCKSZ.
+ */
+#define HASHAGG_READ_BUFFER_SIZE BLCKSZ
+#define HASHAGG_WRITE_BUFFER_SIZE BLCKSZ
+
+/*
+ * HyperLogLog is used for estimating the cardinality of the spilled tuples in
+ * a given partition. 5 bits corresponds to a size of about 32 bytes and a
+ * worst-case error of around 18%. That's effective enough to choose a
+ * reasonable number of partitions when recursing.
+ */
+#define HASHAGG_HLL_BIT_WIDTH 5
+
+/*
+ * Estimate chunk overhead as a constant 16 bytes. XXX: should this be
+ * improved?
+ */
+#define CHUNKHDRSZ 16
+
+#if PG_VERSION_NUM < PG_VERSION_15
+/*
+ * Track all tapes needed for a HashAgg that spills. We don't know the maximum
+ * number of tapes needed at the start of the algorithm (because it can
+ * recurse), so one tape set is allocated and extended as needed for new
+ * tapes. When a particular tape is already read, rewind it for write mode and
+ * put it in the free list.
+ *
+ * Tapes' buffers can take up substantial memory when many tapes are open at
+ * once. We only need one tape open at a time in read mode (using a buffer
+ * that's a multiple of BLCKSZ); but we need one tape open in write mode (each
+ * requiring a buffer of size BLCKSZ) for each partition.
+ */
+typedef struct HashTapeInfo
+{
+	LogicalTapeSet *tapeset;
+	int			ntapes;
+	int		   *freetapes;
+	int			nfreetapes;
+	int			freetapes_alloc;
+} HashTapeInfo;
+#endif
+
+/*
+ * Represents partitioned spill data for a single hashtable. Contains the
+ * necessary information to route tuples to the correct partition, and to
+ * transform the spilled data into new batches.
+ *
+ * The high bits are used for partition selection (when recursing, we ignore
+ * the bits that have already been used for partition selection at an earlier
+ * level).
+ */
+typedef struct HashAggSpill
+{
+#if PG_VERSION_NUM < PG_VERSION_15
+	LogicalTapeSet *tapeset;	/* borrowed reference to tape set */
+#endif
+	int			npartitions;	/* number of partitions */
+#if PG_VERSION_NUM < PG_VERSION_15
+	int		   *partitions;		/* spill partition tape numbers */
+#else
+	LogicalTape **partitions;	/* spill partition tapes */
+#endif
+	int64	   *ntuples;		/* number of tuples in each partition */
+	uint32		mask;			/* mask to find partition from hash value */
+	int			shift;			/* after masking, shift by this amount */
+	hyperLogLogState *hll_card; /* cardinality estimate for contents */
+} HashAggSpill;
+
+/*
+ * Represents work to be done for one pass of hash aggregation (with only one
+ * grouping set).
+ *
+ * Also tracks the bits of the hash already used for partition selection by
+ * earlier iterations, so that this batch can use new bits. If all bits have
+ * already been used, no partitioning will be done (any spilled data will go
+ * to a single output tape).
+ */
+typedef struct HashAggBatch
+{
+	int			setno;			/* grouping set */
+	int			used_bits;		/* number of bits of hash already used */
+#if PG_VERSION_NUM < PG_VERSION_15
+	LogicalTapeSet *tapeset;	/* borrowed reference to tape set */
+	int			input_tapenum;	/* input partition tape */
+#else
+	LogicalTape *input_tape;	/* input partition tape */
+#endif
+	int64		input_tuples;	/* number of tuples in this batch */
+	double		input_card;		/* estimated group cardinality */
+} HashAggBatch;
+
+/* used to find referenced colnos */
+typedef struct FindColsContext
+{
+	bool		is_aggref;		/* is under an aggref */
+	Bitmapset  *aggregated;		/* column references under an aggref */
+	Bitmapset  *unaggregated;	/* other column references */
+} FindColsContext;
+
+static void select_current_set(AggState *aggstate, int setno, bool is_hash);
+static void initialize_phase(AggState *aggstate, int newphase);
+static TupleTableSlot *fetch_input_tuple(AggState *aggstate);
+static void initialize_aggregates(AggState *aggstate,
+								  AggStatePerGroup *pergroups,
+								  int numReset);
+static void advance_transition_function(AggState *aggstate,
+										AggStatePerTrans pertrans,
+										AggStatePerGroup pergroupstate);
+static void advance_aggregates(AggState *aggstate);
+static void process_ordered_aggregate_single(AggState *aggstate,
+											 AggStatePerTrans pertrans,
+											 AggStatePerGroup pergroupstate);
+static void process_ordered_aggregate_multi(AggState *aggstate,
+											AggStatePerTrans pertrans,
+											AggStatePerGroup pergroupstate);
+static void finalize_aggregate(AggState *aggstate,
+							   AggStatePerAgg peragg,
+							   AggStatePerGroup pergroupstate,
+							   Datum *resultVal, bool *resultIsNull);
+static void finalize_partialaggregate(AggState *aggstate,
+									  AggStatePerAgg peragg,
+									  AggStatePerGroup pergroupstate,
+									  Datum *resultVal, bool *resultIsNull);
+static inline void prepare_hash_slot(AggStatePerHash perhash,
+									 TupleTableSlot *inputslot,
+									 TupleTableSlot *hashslot);
+static void prepare_projection_slot(AggState *aggstate,
+									TupleTableSlot *slot,
+									int currentSet);
+static void finalize_aggregates(AggState *aggstate,
+								AggStatePerAgg peragg,
+								AggStatePerGroup pergroup);
+static TupleTableSlot *project_aggregates(AggState *aggstate);
+static void find_cols(AggState *aggstate, Bitmapset **aggregated,
+					  Bitmapset **unaggregated);
+static bool find_cols_walker(Node *node, FindColsContext *context);
+static void build_hash_tables(AggState *aggstate);
+static void build_hash_table(AggState *aggstate, int setno, long nbuckets);
+static void hashagg_recompile_expressions(AggState *aggstate, bool minslot,
+										  bool nullcheck);
+static long hash_choose_num_buckets(double hashentrysize,
+									long estimated_nbuckets,
+									Size memory);
+static int	hash_choose_num_partitions(double input_groups,
+									   double hashentrysize,
+									   int used_bits,
+									   int *log2_npartittions);
+static void initialize_hash_entry(AggState *aggstate,
+								  TupleHashTable hashtable,
+								  TupleHashEntry entry);
+static void lookup_hash_entries(AggState *aggstate);
+static TupleTableSlot *agg_retrieve_direct(VectorAggState *vectoraggstate);
+static void agg_fill_hash_table(AggState *aggstate);
+static bool agg_refill_hash_table(AggState *aggstate);
+static TupleTableSlot *agg_retrieve_hash_table(AggState *aggstate);
+static TupleTableSlot *agg_retrieve_hash_table_in_memory(AggState *aggstate);
+static void hash_agg_check_limits(AggState *aggstate);
+static void hash_agg_enter_spill_mode(AggState *aggstate);
+static void hash_agg_update_metrics(AggState *aggstate, bool from_tape,
+									int npartitions);
+static void hashagg_finish_initial_spills(AggState *aggstate);
+static void hashagg_reset_spill_state(AggState *aggstate);
+#if PG_VERSION_NUM < PG_VERSION_15
+static HashAggBatch *hashagg_batch_new(LogicalTapeSet *tapeset,
+									   int input_tapenum, int setno,
+#else
+static HashAggBatch *hashagg_batch_new(LogicalTape *input_tape, int setno,
+#endif
+									   int64 input_tuples, double input_card,
+									   int used_bits);
+static MinimalTuple hashagg_batch_read(HashAggBatch *batch, uint32 *hashp);
+#if PG_VERSION_NUM < PG_VERSION_15
+static void hashagg_spill_init(HashAggSpill *spill, HashTapeInfo *tapeinfo,
+#else
+static void hashagg_spill_init(HashAggSpill *spill, LogicalTapeSet *lts,
+#endif
+							   int used_bits, double input_groups,
+							   double hashentrysize);
+static Size hashagg_spill_tuple(AggState *aggstate, HashAggSpill *spill,
+								TupleTableSlot *slot, uint32 hash);
+static void hashagg_spill_finish(AggState *aggstate, HashAggSpill *spill,
+								 int setno);
+#if PG_VERSION_NUM < PG_VERSION_15
+static void hashagg_tapeinfo_init(AggState *aggstate);
+static void hashagg_tapeinfo_assign(HashTapeInfo *tapeinfo, int *dest,
+									int ndest);
+static void hashagg_tapeinfo_release(HashTapeInfo *tapeinfo, int tapenum);
+#endif
+static Datum GetAggInitVal(Datum textInitVal, Oid transtype);
+static void build_pertrans_for_aggref(AggStatePerTrans pertrans,
+									  AggState *aggstate, EState *estate,
+#if PG_VERSION_NUM < PG_VERSION_15
+									  Aggref *aggref, Oid aggtransfn, Oid aggtranstype,
+									  Oid aggserialfn, Oid aggdeserialfn,
+									  Datum initValue, bool initValueIsNull,
+									  Oid *inputTypes, int numArguments);
+#else
+									  Aggref *aggref, Oid transfn_oid,
+									  Oid aggtranstype, Oid aggserialfn,
+									  Oid aggdeserialfn, Datum initValue,
+									  bool initValueIsNull, Oid *inputTypes,
+									  int numArguments);
+#endif
+static AggState * VExecInitAgg(Agg *node, EState *estate, int eflags);
+
+/*
+ * Select the current grouping set; affects current_set and
+ * curaggcontext.
+ */
+static void
+select_current_set(AggState *aggstate, int setno, bool is_hash)
+{
+	/*
+	 * When changing this, also adapt ExecAggPlainTransByVal() and
+	 * ExecAggPlainTransByRef().
+	 */
+	if (is_hash)
+		aggstate->curaggcontext = aggstate->hashcontext;
+	else
+		aggstate->curaggcontext = aggstate->aggcontexts[setno];
+
+	aggstate->current_set = setno;
+}
+
+/*
+ * Switch to phase "newphase", which must either be 0 or 1 (to reset) or
+ * current_phase + 1. Juggle the tuplesorts accordingly.
+ *
+ * Phase 0 is for hashing, which we currently handle last in the AGG_MIXED
+ * case, so when entering phase 0, all we need to do is drop open sorts.
+ */
+static void
+initialize_phase(AggState *aggstate, int newphase)
+{
+	Assert(newphase <= 1 || newphase == aggstate->current_phase + 1);
+
+	/*
+	 * Whatever the previous state, we're now done with whatever input
+	 * tuplesort was in use.
+	 */
+	if (aggstate->sort_in)
+	{
+		tuplesort_end(aggstate->sort_in);
+		aggstate->sort_in = NULL;
+	}
+
+	if (newphase <= 1)
+	{
+		/*
+		 * Discard any existing output tuplesort.
+		 */
+		if (aggstate->sort_out)
+		{
+			tuplesort_end(aggstate->sort_out);
+			aggstate->sort_out = NULL;
+		}
+	}
+	else
+	{
+		/*
+		 * The old output tuplesort becomes the new input one, and this is the
+		 * right time to actually sort it.
+		 */
+		aggstate->sort_in = aggstate->sort_out;
+		aggstate->sort_out = NULL;
+		Assert(aggstate->sort_in);
+		tuplesort_performsort(aggstate->sort_in);
+	}
+
+	/*
+	 * If this isn't the last phase, we need to sort appropriately for the
+	 * next phase in sequence.
+	 */
+	if (newphase > 0 && newphase < aggstate->numphases - 1)
+	{
+		Sort	   *sortnode = aggstate->phases[newphase + 1].sortnode;
+		PlanState  *outerNode = outerPlanState(aggstate);
+		TupleDesc	tupDesc = ExecGetResultType(outerNode);
+
+		aggstate->sort_out = tuplesort_begin_heap(tupDesc,
+												  sortnode->numCols,
+												  sortnode->sortColIdx,
+												  sortnode->sortOperators,
+												  sortnode->collations,
+												  sortnode->nullsFirst,
+												  work_mem,
+#if PG_VERSION_NUM < PG_VERSION_15
+												  NULL, false);
+#else
+												  NULL, TUPLESORT_NONE);
+#endif
+	}
+
+	aggstate->current_phase = newphase;
+	aggstate->phase = &aggstate->phases[newphase];
+}
+
+/*
+ * Fetch a tuple from either the outer plan (for phase 1) or from the sorter
+ * populated by the previous phase.  Copy it to the sorter for the next phase
+ * if any.
+ *
+ * Callers cannot rely on memory for tuple in returned slot remaining valid
+ * past any subsequently fetched tuple.
+ */
+static TupleTableSlot *
+fetch_input_tuple(AggState *aggstate)
+{
+	TupleTableSlot *slot;
+
+	if (aggstate->sort_in)
+	{
+		/* make sure we check for interrupts in either path through here */
+		CHECK_FOR_INTERRUPTS();
+		if (!tuplesort_gettupleslot(aggstate->sort_in, true, false,
+									aggstate->sort_slot, NULL))
+			return NULL;
+		slot = aggstate->sort_slot;
+	}
+	else
+		slot = ExecProcNode(outerPlanState(aggstate));
+
+	if (!TupIsNull(slot) && aggstate->sort_out)
+		tuplesort_puttupleslot(aggstate->sort_out, slot);
+
+	return slot;
+}
+
+/*
+ * (Re)Initialize an individual aggregate.
+ *
+ * This function handles only one grouping set, already set in
+ * aggstate->current_set.
+ *
+ * When called, CurrentMemoryContext should be the per-query context.
+ */
+static void
+initialize_aggregate(AggState *aggstate, AggStatePerTrans pertrans,
+					 AggStatePerGroup pergroupstate)
+{
+	/*
+	 * Start a fresh sort operation for each DISTINCT/ORDER BY aggregate.
+	 */
+	if (pertrans->numSortCols > 0)
+	{
+		/*
+		 * In case of rescan, maybe there could be an uncompleted sort
+		 * operation?  Clean it up if so.
+		 */
+		if (pertrans->sortstates[aggstate->current_set])
+			tuplesort_end(pertrans->sortstates[aggstate->current_set]);
+
+
+		/*
+		 * We use a plain Datum sorter when there's a single input column;
+		 * otherwise sort the full tuple.  (See comments for
+		 * process_ordered_aggregate_single.)
+		 */
+		if (pertrans->numInputs == 1)
+		{
+			Form_pg_attribute attr = TupleDescAttr(pertrans->sortdesc, 0);
+
+			pertrans->sortstates[aggstate->current_set] =
+				tuplesort_begin_datum(attr->atttypid,
+									  pertrans->sortOperators[0],
+									  pertrans->sortCollations[0],
+									  pertrans->sortNullsFirst[0],
+#if PG_VERSION_NUM < PG_VERSION_15
+									  work_mem, NULL, false);
+#else
+									  work_mem, NULL, TUPLESORT_NONE);
+#endif
+		}
+		else
+			pertrans->sortstates[aggstate->current_set] =
+				tuplesort_begin_heap(pertrans->sortdesc,
+									 pertrans->numSortCols,
+									 pertrans->sortColIdx,
+									 pertrans->sortOperators,
+									 pertrans->sortCollations,
+									 pertrans->sortNullsFirst,
+#if PG_VERSION_NUM < PG_VERSION_15
+									 work_mem, NULL, false);
+#else
+									 work_mem, NULL, TUPLESORT_NONE);
+#endif
+	}
+
+	/*
+	 * (Re)set transValue to the initial value.
+	 *
+	 * Note that when the initial value is pass-by-ref, we must copy it (into
+	 * the aggcontext) since we will pfree the transValue later.
+	 */
+	if (pertrans->initValueIsNull)
+		pergroupstate->transValue = pertrans->initValue;
+	else
+	{
+		MemoryContext oldContext;
+
+		oldContext = MemoryContextSwitchTo(aggstate->curaggcontext->ecxt_per_tuple_memory);
+		pergroupstate->transValue = datumCopy(pertrans->initValue,
+											  pertrans->transtypeByVal,
+											  pertrans->transtypeLen);
+		MemoryContextSwitchTo(oldContext);
+	}
+	pergroupstate->transValueIsNull = pertrans->initValueIsNull;
+
+	/*
+	 * If the initial value for the transition state doesn't exist in the
+	 * pg_aggregate table then we will let the first non-NULL value returned
+	 * from the outer procNode become the initial value. (This is useful for
+	 * aggregates like max() and min().) The noTransValue flag signals that we
+	 * still need to do this.
+	 */
+	pergroupstate->noTransValue = pertrans->initValueIsNull;
+}
+
+/*
+ * Initialize all aggregate transition states for a new group of input values.
+ *
+ * If there are multiple grouping sets, we initialize only the first numReset
+ * of them (the grouping sets are ordered so that the most specific one, which
+ * is reset most often, is first). As a convenience, if numReset is 0, we
+ * reinitialize all sets.
+ *
+ * NB: This cannot be used for hash aggregates, as for those the grouping set
+ * number has to be specified from further up.
+ *
+ * When called, CurrentMemoryContext should be the per-query context.
+ */
+static void
+initialize_aggregates(AggState *aggstate,
+					  AggStatePerGroup *pergroups,
+					  int numReset)
+{
+	int			transno;
+	int			numGroupingSets = Max(aggstate->phase->numsets, 1);
+	int			setno = 0;
+	int			numTrans = aggstate->numtrans;
+	AggStatePerTrans transstates = aggstate->pertrans;
+
+	if (numReset == 0)
+		numReset = numGroupingSets;
+
+	for (setno = 0; setno < numReset; setno++)
+	{
+		AggStatePerGroup pergroup = pergroups[setno];
+
+		select_current_set(aggstate, setno, false);
+
+		for (transno = 0; transno < numTrans; transno++)
+		{
+			AggStatePerTrans pertrans = &transstates[transno];
+			AggStatePerGroup pergroupstate = &pergroup[transno];
+
+			initialize_aggregate(aggstate, pertrans, pergroupstate);
+		}
+	}
+}
+
+/*
+ * Given new input value(s), advance the transition function of one aggregate
+ * state within one grouping set only (already set in aggstate->current_set)
+ *
+ * The new values (and null flags) have been preloaded into argument positions
+ * 1 and up in pertrans->transfn_fcinfo, so that we needn't copy them again to
+ * pass to the transition function.  We also expect that the static fields of
+ * the fcinfo are already initialized; that was done by ExecInitAgg().
+ *
+ * It doesn't matter which memory context this is called in.
+ */
+static void
+advance_transition_function(AggState *aggstate,
+							AggStatePerTrans pertrans,
+							AggStatePerGroup pergroupstate)
+{
+	FunctionCallInfo fcinfo = pertrans->transfn_fcinfo;
+	MemoryContext oldContext;
+	Datum		newVal;
+
+	if (pertrans->transfn.fn_strict)
+	{
+		/*
+		 * For a strict transfn, nothing happens when there's a NULL input; we
+		 * just keep the prior transValue.
+		 */
+		int			numTransInputs = pertrans->numTransInputs;
+		int			i;
+
+		for (i = 1; i <= numTransInputs; i++)
+		{
+			if (fcinfo->args[i].isnull)
+				return;
+		}
+		if (pergroupstate->noTransValue)
+		{
+			/*
+			 * transValue has not been initialized. This is the first non-NULL
+			 * input value. We use it as the initial value for transValue. (We
+			 * already checked that the agg's input type is binary-compatible
+			 * with its transtype, so straight copy here is OK.)
+			 *
+			 * We must copy the datum into aggcontext if it is pass-by-ref. We
+			 * do not need to pfree the old transValue, since it's NULL.
+			 */
+			oldContext = MemoryContextSwitchTo(aggstate->curaggcontext->ecxt_per_tuple_memory);
+			pergroupstate->transValue = datumCopy(fcinfo->args[1].value,
+												  pertrans->transtypeByVal,
+												  pertrans->transtypeLen);
+			pergroupstate->transValueIsNull = false;
+			pergroupstate->noTransValue = false;
+			MemoryContextSwitchTo(oldContext);
+			return;
+		}
+		if (pergroupstate->transValueIsNull)
+		{
+			/*
+			 * Don't call a strict function with NULL inputs.  Note it is
+			 * possible to get here despite the above tests, if the transfn is
+			 * strict *and* returned a NULL on a prior cycle. If that happens
+			 * we will propagate the NULL all the way to the end.
+			 */
+			return;
+		}
+	}
+
+	/* We run the transition functions in per-input-tuple memory context */
+	oldContext = MemoryContextSwitchTo(aggstate->tmpcontext->ecxt_per_tuple_memory);
+
+	/* set up aggstate->curpertrans for AggGetAggref() */
+	aggstate->curpertrans = pertrans;
+
+	/*
+	 * OK to call the transition function
+	 */
+	fcinfo->args[0].value = pergroupstate->transValue;
+	fcinfo->args[0].isnull = pergroupstate->transValueIsNull;
+	fcinfo->isnull = false;		/* just in case transfn doesn't set it */
+
+	newVal = FunctionCallInvoke(fcinfo);
+
+	aggstate->curpertrans = NULL;
+
+	/*
+	 * If pass-by-ref datatype, must copy the new value into aggcontext and
+	 * free the prior transValue.  But if transfn returned a pointer to its
+	 * first input, we don't need to do anything.  Also, if transfn returned a
+	 * pointer to a R/W expanded object that is already a child of the
+	 * aggcontext, assume we can adopt that value without copying it.
+	 *
+	 * It's safe to compare newVal with pergroup->transValue without regard
+	 * for either being NULL, because ExecAggTransReparent() takes care to set
+	 * transValue to 0 when NULL. Otherwise we could end up accidentally not
+	 * reparenting, when the transValue has the same numerical value as
+	 * newValue, despite being NULL.  This is a somewhat hot path, making it
+	 * undesirable to instead solve this with another branch for the common
+	 * case of the transition function returning its (modified) input
+	 * argument.
+	 */
+	if (!pertrans->transtypeByVal &&
+		DatumGetPointer(newVal) != DatumGetPointer(pergroupstate->transValue))
+		newVal = ExecAggTransReparent(aggstate, pertrans,
+									  newVal, fcinfo->isnull,
+									  pergroupstate->transValue,
+									  pergroupstate->transValueIsNull);
+
+	pergroupstate->transValue = newVal;
+	pergroupstate->transValueIsNull = fcinfo->isnull;
+
+	MemoryContextSwitchTo(oldContext);
+}
+
+/*
+ * Advance each aggregate transition state for one input tuple.  The input
+ * tuple has been stored in tmpcontext->ecxt_outertuple, so that it is
+ * accessible to ExecEvalExpr.
+ *
+ * We have two sets of transition states to handle: one for sorted aggregation
+ * and one for hashed; we do them both here, to avoid multiple evaluation of
+ * the inputs.
+ *
+ * When called, CurrentMemoryContext should be the per-query context.
+ */
+static void
+advance_aggregates(AggState *aggstate)
+{
+	bool		dummynull;
+
+	ExecEvalExprSwitchContext(aggstate->phase->evaltrans,
+							  aggstate->tmpcontext,
+							  &dummynull);
+}
+
+/*
+ * Run the transition function for a DISTINCT or ORDER BY aggregate
+ * with only one input.  This is called after we have completed
+ * entering all the input values into the sort object.  We complete the
+ * sort, read out the values in sorted order, and run the transition
+ * function on each value (applying DISTINCT if appropriate).
+ *
+ * Note that the strictness of the transition function was checked when
+ * entering the values into the sort, so we don't check it again here;
+ * we just apply standard SQL DISTINCT logic.
+ *
+ * The one-input case is handled separately from the multi-input case
+ * for performance reasons: for single by-value inputs, such as the
+ * common case of count(distinct id), the tuplesort_getdatum code path
+ * is around 300% faster.  (The speedup for by-reference types is less
+ * but still noticeable.)
+ *
+ * This function handles only one grouping set (already set in
+ * aggstate->current_set).
+ *
+ * When called, CurrentMemoryContext should be the per-query context.
+ */
+static void
+process_ordered_aggregate_single(AggState *aggstate,
+								 AggStatePerTrans pertrans,
+								 AggStatePerGroup pergroupstate)
+{
+	Datum		oldVal = (Datum) 0;
+	bool		oldIsNull = true;
+	bool		haveOldVal = false;
+	MemoryContext workcontext = aggstate->tmpcontext->ecxt_per_tuple_memory;
+	MemoryContext oldContext;
+	bool		isDistinct = (pertrans->numDistinctCols > 0);
+	Datum		newAbbrevVal = (Datum) 0;
+	Datum		oldAbbrevVal = (Datum) 0;
+	FunctionCallInfo fcinfo = pertrans->transfn_fcinfo;
+	Datum	   *newVal;
+	bool	   *isNull;
+
+	Assert(pertrans->numDistinctCols < 2);
+
+	tuplesort_performsort(pertrans->sortstates[aggstate->current_set]);
+
+	/* Load the column into argument 1 (arg 0 will be transition value) */
+	newVal = &fcinfo->args[1].value;
+	isNull = &fcinfo->args[1].isnull;
+
+	/*
+	 * Note: if input type is pass-by-ref, the datums returned by the sort are
+	 * freshly palloc'd in the per-query context, so we must be careful to
+	 * pfree them when they are no longer needed.
+	 */
+
+	while (tuplesort_getdatum(pertrans->sortstates[aggstate->current_set],
+							  true, newVal, isNull, &newAbbrevVal))
+	{
+		/*
+		 * Clear and select the working context for evaluation of the equality
+		 * function and transition function.
+		 */
+		MemoryContextReset(workcontext);
+		oldContext = MemoryContextSwitchTo(workcontext);
+
+		/*
+		 * If DISTINCT mode, and not distinct from prior, skip it.
+		 */
+		if (isDistinct &&
+			haveOldVal &&
+			((oldIsNull && *isNull) ||
+			 (!oldIsNull && !*isNull &&
+			  oldAbbrevVal == newAbbrevVal &&
+			  DatumGetBool(FunctionCall2Coll(&pertrans->equalfnOne,
+											 pertrans->aggCollation,
+											 oldVal, *newVal)))))
+		{
+			/* equal to prior, so forget this one */
+			if (!pertrans->inputtypeByVal && !*isNull)
+				pfree(DatumGetPointer(*newVal));
+		}
+		else
+		{
+			advance_transition_function(aggstate, pertrans, pergroupstate);
+			/* forget the old value, if any */
+			if (!oldIsNull && !pertrans->inputtypeByVal)
+				pfree(DatumGetPointer(oldVal));
+			/* and remember the new one for subsequent equality checks */
+			oldVal = *newVal;
+			oldAbbrevVal = newAbbrevVal;
+			oldIsNull = *isNull;
+			haveOldVal = true;
+		}
+
+		MemoryContextSwitchTo(oldContext);
+	}
+
+	if (!oldIsNull && !pertrans->inputtypeByVal)
+		pfree(DatumGetPointer(oldVal));
+
+	tuplesort_end(pertrans->sortstates[aggstate->current_set]);
+	pertrans->sortstates[aggstate->current_set] = NULL;
+}
+
+/*
+ * Run the transition function for a DISTINCT or ORDER BY aggregate
+ * with more than one input.  This is called after we have completed
+ * entering all the input values into the sort object.  We complete the
+ * sort, read out the values in sorted order, and run the transition
+ * function on each value (applying DISTINCT if appropriate).
+ *
+ * This function handles only one grouping set (already set in
+ * aggstate->current_set).
+ *
+ * When called, CurrentMemoryContext should be the per-query context.
+ */
+static void
+process_ordered_aggregate_multi(AggState *aggstate,
+								AggStatePerTrans pertrans,
+								AggStatePerGroup pergroupstate)
+{
+	ExprContext *tmpcontext = aggstate->tmpcontext;
+	FunctionCallInfo fcinfo = pertrans->transfn_fcinfo;
+	TupleTableSlot *slot1 = pertrans->sortslot;
+	TupleTableSlot *slot2 = pertrans->uniqslot;
+	int			numTransInputs = pertrans->numTransInputs;
+	int			numDistinctCols = pertrans->numDistinctCols;
+	Datum		newAbbrevVal = (Datum) 0;
+	Datum		oldAbbrevVal = (Datum) 0;
+	bool		haveOldValue = false;
+	TupleTableSlot *save = aggstate->tmpcontext->ecxt_outertuple;
+	int			i;
+
+	tuplesort_performsort(pertrans->sortstates[aggstate->current_set]);
+
+	ExecClearTuple(slot1);
+	if (slot2)
+		ExecClearTuple(slot2);
+
+	while (tuplesort_gettupleslot(pertrans->sortstates[aggstate->current_set],
+								  true, true, slot1, &newAbbrevVal))
+	{
+		CHECK_FOR_INTERRUPTS();
+
+		tmpcontext->ecxt_outertuple = slot1;
+		tmpcontext->ecxt_innertuple = slot2;
+
+		if (numDistinctCols == 0 ||
+			!haveOldValue ||
+			newAbbrevVal != oldAbbrevVal ||
+			!ExecQual(pertrans->equalfnMulti, tmpcontext))
+		{
+			/*
+			 * Extract the first numTransInputs columns as datums to pass to
+			 * the transfn.
+			 */
+			slot_getsomeattrs(slot1, numTransInputs);
+
+			/* Load values into fcinfo */
+			/* Start from 1, since the 0th arg will be the transition value */
+			for (i = 0; i < numTransInputs; i++)
+			{
+				fcinfo->args[i + 1].value = slot1->tts_values[i];
+				fcinfo->args[i + 1].isnull = slot1->tts_isnull[i];
+			}
+
+			advance_transition_function(aggstate, pertrans, pergroupstate);
+
+			if (numDistinctCols > 0)
+			{
+				/* swap the slot pointers to retain the current tuple */
+				TupleTableSlot *tmpslot = slot2;
+
+				slot2 = slot1;
+				slot1 = tmpslot;
+				/* avoid ExecQual() calls by reusing abbreviated keys */
+				oldAbbrevVal = newAbbrevVal;
+				haveOldValue = true;
+			}
+		}
+
+		/* Reset context each time */
+		ResetExprContext(tmpcontext);
+
+		ExecClearTuple(slot1);
+	}
+
+	if (slot2)
+		ExecClearTuple(slot2);
+
+	tuplesort_end(pertrans->sortstates[aggstate->current_set]);
+	pertrans->sortstates[aggstate->current_set] = NULL;
+
+	/* restore previous slot, potentially in use for grouping sets */
+	tmpcontext->ecxt_outertuple = save;
+}
+
+/*
+ * Compute the final value of one aggregate.
+ *
+ * This function handles only one grouping set (already set in
+ * aggstate->current_set).
+ *
+ * The finalfn will be run, and the result delivered, in the
+ * output-tuple context; caller's CurrentMemoryContext does not matter.
+ *
+ * The finalfn uses the state as set in the transno. This also might be
+ * being used by another aggregate function, so it's important that we do
+ * nothing destructive here.
+ */
+static void
+finalize_aggregate(AggState *aggstate,
+				   AggStatePerAgg peragg,
+				   AggStatePerGroup pergroupstate,
+				   Datum *resultVal, bool *resultIsNull)
+{
+	LOCAL_FCINFO(fcinfo, FUNC_MAX_ARGS);
+	bool		anynull = false;
+	MemoryContext oldContext;
+	int			i;
+	ListCell   *lc;
+	AggStatePerTrans pertrans = &aggstate->pertrans[peragg->transno];
+
+	oldContext = MemoryContextSwitchTo(aggstate->ss.ps.ps_ExprContext->ecxt_per_tuple_memory);
+
+	/*
+	 * Evaluate any direct arguments.  We do this even if there's no finalfn
+	 * (which is unlikely anyway), so that side-effects happen as expected.
+	 * The direct arguments go into arg positions 1 and up, leaving position 0
+	 * for the transition state value.
+	 */
+	i = 1;
+	foreach(lc, peragg->aggdirectargs)
+	{
+		ExprState  *expr = (ExprState *) lfirst(lc);
+
+		fcinfo->args[i].value = ExecEvalExpr(expr,
+											 aggstate->ss.ps.ps_ExprContext,
+											 &fcinfo->args[i].isnull);
+		anynull |= fcinfo->args[i].isnull;
+		i++;
+	}
+
+	/*
+	 * Apply the agg's finalfn if one is provided, else return transValue.
+	 */
+	if (OidIsValid(peragg->finalfn_oid))
+	{
+		int			numFinalArgs = peragg->numFinalArgs;
+
+		/* set up aggstate->curperagg for AggGetAggref() */
+		aggstate->curperagg = peragg;
+
+		InitFunctionCallInfoData(*fcinfo, &peragg->finalfn,
+								 numFinalArgs,
+								 pertrans->aggCollation,
+								 (void *) aggstate, NULL);
+
+		/* Fill in the transition state value */
+		fcinfo->args[0].value =
+			MakeExpandedObjectReadOnly(pergroupstate->transValue,
+									   pergroupstate->transValueIsNull,
+									   pertrans->transtypeLen);
+		fcinfo->args[0].isnull = pergroupstate->transValueIsNull;
+		anynull |= pergroupstate->transValueIsNull;
+
+		/* Fill any remaining argument positions with nulls */
+		for (; i < numFinalArgs; i++)
+		{
+			fcinfo->args[i].value = (Datum) 0;
+			fcinfo->args[i].isnull = true;
+			anynull = true;
+		}
+
+		if (fcinfo->flinfo->fn_strict && anynull)
+		{
+			/* don't call a strict function with NULL inputs */
+			*resultVal = (Datum) 0;
+			*resultIsNull = true;
+		}
+		else
+		{
+			*resultVal = FunctionCallInvoke(fcinfo);
+			*resultIsNull = fcinfo->isnull;
+		}
+		aggstate->curperagg = NULL;
+	}
+	else
+	{
+		/* Don't need MakeExpandedObjectReadOnly; datumCopy will copy it */
+		*resultVal = pergroupstate->transValue;
+		*resultIsNull = pergroupstate->transValueIsNull;
+	}
+
+	/*
+	 * If result is pass-by-ref, make sure it is in the right context.
+	 */
+	if (!peragg->resulttypeByVal && !*resultIsNull &&
+		!MemoryContextContains(CurrentMemoryContext,
+							   DatumGetPointer(*resultVal)))
+		*resultVal = datumCopy(*resultVal,
+							   peragg->resulttypeByVal,
+							   peragg->resulttypeLen);
+
+	MemoryContextSwitchTo(oldContext);
+}
+
+/*
+ * Compute the output value of one partial aggregate.
+ *
+ * The serialization function will be run, and the result delivered, in the
+ * output-tuple context; caller's CurrentMemoryContext does not matter.
+ */
+static void
+finalize_partialaggregate(AggState *aggstate,
+						  AggStatePerAgg peragg,
+						  AggStatePerGroup pergroupstate,
+						  Datum *resultVal, bool *resultIsNull)
+{
+	AggStatePerTrans pertrans = &aggstate->pertrans[peragg->transno];
+	MemoryContext oldContext;
+
+	oldContext = MemoryContextSwitchTo(aggstate->ss.ps.ps_ExprContext->ecxt_per_tuple_memory);
+
+	/*
+	 * serialfn_oid will be set if we must serialize the transvalue before
+	 * returning it
+	 */
+	if (OidIsValid(pertrans->serialfn_oid))
+	{
+		/* Don't call a strict serialization function with NULL input. */
+		if (pertrans->serialfn.fn_strict && pergroupstate->transValueIsNull)
+		{
+			*resultVal = (Datum) 0;
+			*resultIsNull = true;
+		}
+		else
+		{
+			FunctionCallInfo fcinfo = pertrans->serialfn_fcinfo;
+
+			fcinfo->args[0].value =
+				MakeExpandedObjectReadOnly(pergroupstate->transValue,
+										   pergroupstate->transValueIsNull,
+										   pertrans->transtypeLen);
+			fcinfo->args[0].isnull = pergroupstate->transValueIsNull;
+			fcinfo->isnull = false;
+
+			*resultVal = FunctionCallInvoke(fcinfo);
+			*resultIsNull = fcinfo->isnull;
+		}
+	}
+	else
+	{
+		/* Don't need MakeExpandedObjectReadOnly; datumCopy will copy it */
+		*resultVal = pergroupstate->transValue;
+		*resultIsNull = pergroupstate->transValueIsNull;
+	}
+
+	/* If result is pass-by-ref, make sure it is in the right context. */
+	if (!peragg->resulttypeByVal && !*resultIsNull &&
+		!MemoryContextContains(CurrentMemoryContext,
+							   DatumGetPointer(*resultVal)))
+		*resultVal = datumCopy(*resultVal,
+							   peragg->resulttypeByVal,
+							   peragg->resulttypeLen);
+
+	MemoryContextSwitchTo(oldContext);
+}
+
+/*
+ * Extract the attributes that make up the grouping key into the
+ * hashslot. This is necessary to compute the hash or perform a lookup.
+ */
+static inline void
+prepare_hash_slot(AggStatePerHash perhash,
+				  TupleTableSlot *inputslot,
+				  TupleTableSlot *hashslot)
+{
+	int			i;
+
+	/* transfer just the needed columns into hashslot */
+	slot_getsomeattrs(inputslot, perhash->largestGrpColIdx);
+	ExecClearTuple(hashslot);
+
+	for (i = 0; i < perhash->numhashGrpCols; i++)
+	{
+		int			varNumber = perhash->hashGrpColIdxInput[i] - 1;
+
+		hashslot->tts_values[i] = inputslot->tts_values[varNumber];
+		hashslot->tts_isnull[i] = inputslot->tts_isnull[varNumber];
+	}
+	ExecStoreVirtualTuple(hashslot);
+}
+
+/*
+ * Prepare to finalize and project based on the specified representative tuple
+ * slot and grouping set.
+ *
+ * In the specified tuple slot, force to null all attributes that should be
+ * read as null in the context of the current grouping set.  Also stash the
+ * current group bitmap where GroupingExpr can get at it.
+ *
+ * This relies on three conditions:
+ *
+ * 1) Nothing is ever going to try and extract the whole tuple from this slot,
+ * only reference it in evaluations, which will only access individual
+ * attributes.
+ *
+ * 2) No system columns are going to need to be nulled. (If a system column is
+ * referenced in a group clause, it is actually projected in the outer plan
+ * tlist.)
+ *
+ * 3) Within a given phase, we never need to recover the value of an attribute
+ * once it has been set to null.
+ *
+ * Poking into the slot this way is a bit ugly, but the consensus is that the
+ * alternative was worse.
+ */
+static void
+prepare_projection_slot(AggState *aggstate, TupleTableSlot *slot, int currentSet)
+{
+	if (aggstate->phase->grouped_cols)
+	{
+		Bitmapset  *grouped_cols = aggstate->phase->grouped_cols[currentSet];
+
+		aggstate->grouped_cols = grouped_cols;
+
+		if (TTS_EMPTY(slot))
+		{
+			/*
+			 * Force all values to be NULL if working on an empty input tuple
+			 * (i.e. an empty grouping set for which no input rows were
+			 * supplied).
+			 */
+			ExecStoreAllNullTuple(slot);
+		}
+		else if (aggstate->all_grouped_cols)
+		{
+			ListCell   *lc;
+
+			/* all_grouped_cols is arranged in desc order */
+			slot_getsomeattrs(slot, linitial_int(aggstate->all_grouped_cols));
+
+			foreach(lc, aggstate->all_grouped_cols)
+			{
+				int			attnum = lfirst_int(lc);
+
+				if (!bms_is_member(attnum, grouped_cols))
+					slot->tts_isnull[attnum - 1] = true;
+			}
+		}
+	}
+}
+
+/*
+ * Compute the final value of all aggregates for one group.
+ *
+ * This function handles only one grouping set at a time, which the caller must
+ * have selected.  It's also the caller's responsibility to adjust the supplied
+ * pergroup parameter to point to the current set's transvalues.
+ *
+ * Results are stored in the output econtext aggvalues/aggnulls.
+ */
+static void
+finalize_aggregates(AggState *aggstate,
+					AggStatePerAgg peraggs,
+					AggStatePerGroup pergroup)
+{
+	ExprContext *econtext = aggstate->ss.ps.ps_ExprContext;
+	Datum	   *aggvalues = econtext->ecxt_aggvalues;
+	bool	   *aggnulls = econtext->ecxt_aggnulls;
+	int			aggno;
+	int			transno;
+
+	/*
+	 * If there were any DISTINCT and/or ORDER BY aggregates, sort their
+	 * inputs and run the transition functions.
+	 */
+	for (transno = 0; transno < aggstate->numtrans; transno++)
+	{
+		AggStatePerTrans pertrans = &aggstate->pertrans[transno];
+		AggStatePerGroup pergroupstate;
+
+		pergroupstate = &pergroup[transno];
+
+		if (pertrans->numSortCols > 0)
+		{
+			Assert(aggstate->aggstrategy != AGG_HASHED &&
+				   aggstate->aggstrategy != AGG_MIXED);
+
+			if (pertrans->numInputs == 1)
+				process_ordered_aggregate_single(aggstate,
+												 pertrans,
+												 pergroupstate);
+			else
+				process_ordered_aggregate_multi(aggstate,
+												pertrans,
+												pergroupstate);
+		}
+	}
+
+	/*
+	 * Run the final functions.
+	 */
+	for (aggno = 0; aggno < aggstate->numaggs; aggno++)
+	{
+		AggStatePerAgg peragg = &peraggs[aggno];
+		transno = peragg->transno;
+		AggStatePerGroup pergroupstate;
+
+		pergroupstate = &pergroup[transno];
+
+		if (DO_AGGSPLIT_SKIPFINAL(aggstate->aggsplit))
+			finalize_partialaggregate(aggstate, peragg, pergroupstate,
+									  &aggvalues[aggno], &aggnulls[aggno]);
+		else
+			finalize_aggregate(aggstate, peragg, pergroupstate,
+							   &aggvalues[aggno], &aggnulls[aggno]);
+	}
+}
+
+/*
+ * Project the result of a group (whose aggs have already been calculated by
+ * finalize_aggregates). Returns the result slot, or NULL if no row is
+ * projected (suppressed by qual).
+ */
+static TupleTableSlot *
+project_aggregates(AggState *aggstate)
+{
+	ExprContext *econtext = aggstate->ss.ps.ps_ExprContext;
+
+	/*
+	 * Check the qual (HAVING clause); if the group does not match, ignore it.
+	 */
+	if (ExecQual(aggstate->ss.ps.qual, econtext))
+	{
+		/*
+		 * Form and return projection tuple using the aggregate results and
+		 * the representative input tuple.
+		 */
+		return ExecProject(aggstate->ss.ps.ps_ProjInfo);
+	}
+	else
+		InstrCountFiltered1(aggstate, 1);
+
+	return NULL;
+}
+
+/*
+ * Find input-tuple columns that are needed, dividing them into
+ * aggregated and unaggregated sets.
+ */
+static void
+find_cols(AggState *aggstate, Bitmapset **aggregated, Bitmapset **unaggregated)
+{
+	Agg		   *agg = (Agg *) aggstate->ss.ps.plan;
+	FindColsContext context;
+
+	context.is_aggref = false;
+	context.aggregated = NULL;
+	context.unaggregated = NULL;
+
+	/* Examine tlist and quals */
+	(void) find_cols_walker((Node *) agg->plan.targetlist, &context);
+	(void) find_cols_walker((Node *) agg->plan.qual, &context);
+
+	/* In some cases, grouping columns will not appear in the tlist */
+	for (int i = 0; i < agg->numCols; i++)
+		context.unaggregated = bms_add_member(context.unaggregated,
+											  agg->grpColIdx[i]);
+
+	*aggregated = context.aggregated;
+	*unaggregated = context.unaggregated;
+}
+
+static bool
+find_cols_walker(Node *node, FindColsContext *context)
+{
+	if (node == NULL)
+		return false;
+	if (IsA(node, Var))
+	{
+		Var		   *var = (Var *) node;
+
+		/* setrefs.c should have set the varno to OUTER_VAR */
+		Assert(var->varno == OUTER_VAR);
+		Assert(var->varlevelsup == 0);
+		if (context->is_aggref)
+			context->aggregated = bms_add_member(context->aggregated,
+												 var->varattno);
+		else
+			context->unaggregated = bms_add_member(context->unaggregated,
+												   var->varattno);
+		return false;
+	}
+	if (IsA(node, Aggref))
+	{
+		Assert(!context->is_aggref);
+		context->is_aggref = true;
+		expression_tree_walker(node, find_cols_walker, (void *) context);
+		context->is_aggref = false;
+		return false;
+	}
+	return expression_tree_walker(node, find_cols_walker,
+								  (void *) context);
+}
+
+/*
+ * (Re-)initialize the hash table(s) to empty.
+ *
+ * To implement hashed aggregation, we need a hashtable that stores a
+ * representative tuple and an array of AggStatePerGroup structs for each
+ * distinct set of GROUP BY column values.  We compute the hash key from the
+ * GROUP BY columns.  The per-group data is allocated in lookup_hash_entry(),
+ * for each entry.
+ *
+ * We have a separate hashtable and associated perhash data structure for each
+ * grouping set for which we're doing hashing.
+ *
+ * The contents of the hash tables always live in the hashcontext's per-tuple
+ * memory context (there is only one of these for all tables together, since
+ * they are all reset at the same time).
+ */
+static void
+build_hash_tables(AggState *aggstate)
+{
+	int			setno;
+
+	for (setno = 0; setno < aggstate->num_hashes; ++setno)
+	{
+		AggStatePerHash perhash = &aggstate->perhash[setno];
+		long		nbuckets;
+		Size		memory;
+
+		if (perhash->hashtable != NULL)
+		{
+			ResetTupleHashTable(perhash->hashtable);
+			continue;
+		}
+
+		Assert(perhash->aggnode->numGroups > 0);
+
+		memory = aggstate->hash_mem_limit / aggstate->num_hashes;
+
+		/* choose reasonable number of buckets per hashtable */
+		nbuckets = hash_choose_num_buckets(aggstate->hashentrysize,
+										   perhash->aggnode->numGroups,
+										   memory);
+
+		build_hash_table(aggstate, setno, nbuckets);
+	}
+
+	aggstate->hash_ngroups_current = 0;
+}
+
+/*
+ * Build a single hashtable for this grouping set.
+ */
+static void
+build_hash_table(AggState *aggstate, int setno, long nbuckets)
+{
+	AggStatePerHash perhash = &aggstate->perhash[setno];
+	MemoryContext metacxt = aggstate->hash_metacxt;
+	MemoryContext hashcxt = aggstate->hashcontext->ecxt_per_tuple_memory;
+	MemoryContext tmpcxt = aggstate->tmpcontext->ecxt_per_tuple_memory;
+	Size		additionalsize;
+
+	Assert(aggstate->aggstrategy == AGG_HASHED ||
+		   aggstate->aggstrategy == AGG_MIXED);
+
+	/*
+	 * Used to make sure initial hash table allocation does not exceed
+	 * hash_mem. Note that the estimate does not include space for
+	 * pass-by-reference transition data values, nor for the representative
+	 * tuple of each group.
+	 */
+	additionalsize = aggstate->numtrans * sizeof(AggStatePerGroupData);
+
+	perhash->hashtable = BuildTupleHashTableExt(&aggstate->ss.ps,
+												perhash->hashslot->tts_tupleDescriptor,
+												perhash->numCols,
+												perhash->hashGrpColIdxHash,
+												perhash->eqfuncoids,
+												perhash->hashfunctions,
+												perhash->aggnode->grpCollations,
+												nbuckets,
+												additionalsize,
+												metacxt,
+												hashcxt,
+												tmpcxt,
+												DO_AGGSPLIT_SKIPFINAL(aggstate->aggsplit));
+}
+
+/*
+ * Compute columns that actually need to be stored in hashtable entries.  The
+ * incoming tuples from the child plan node will contain grouping columns,
+ * other columns referenced in our targetlist and qual, columns used to
+ * compute the aggregate functions, and perhaps just junk columns we don't use
+ * at all.  Only columns of the first two types need to be stored in the
+ * hashtable, and getting rid of the others can make the table entries
+ * significantly smaller.  The hashtable only contains the relevant columns,
+ * and is packed/unpacked in lookup_hash_entry() / agg_retrieve_hash_table()
+ * into the format of the normal input descriptor.
+ *
+ * Additional columns, in addition to the columns grouped by, come from two
+ * sources: Firstly functionally dependent columns that we don't need to group
+ * by themselves, and secondly ctids for row-marks.
+ *
+ * To eliminate duplicates, we build a bitmapset of the needed columns, and
+ * then build an array of the columns included in the hashtable. We might
+ * still have duplicates if the passed-in grpColIdx has them, which can happen
+ * in edge cases from semijoins/distinct; these can't always be removed,
+ * because it's not certain that the duplicate cols will be using the same
+ * hash function.
+ *
+ * Note that the array is preserved over ExecReScanAgg, so we allocate it in
+ * the per-query context (unlike the hash table itself).
+ */
+static void
+find_hash_columns(AggState *aggstate)
+{
+	Bitmapset  *base_colnos;
+	Bitmapset  *aggregated_colnos;
+	TupleDesc	scanDesc = aggstate->ss.ss_ScanTupleSlot->tts_tupleDescriptor;
+	List	   *outerTlist = outerPlanState(aggstate)->plan->targetlist;
+	int			numHashes = aggstate->num_hashes;
+	EState	   *estate = aggstate->ss.ps.state;
+	int			j;
+
+	/* Find Vars that will be needed in tlist and qual */
+	find_cols(aggstate, &aggregated_colnos, &base_colnos);
+	aggstate->colnos_needed = bms_union(base_colnos, aggregated_colnos);
+	aggstate->max_colno_needed = 0;
+	aggstate->all_cols_needed = true;
+
+	for (int i = 0; i < scanDesc->natts; i++)
+	{
+		int			colno = i + 1;
+
+		if (bms_is_member(colno, aggstate->colnos_needed))
+			aggstate->max_colno_needed = colno;
+		else
+			aggstate->all_cols_needed = false;
+	}
+
+	for (j = 0; j < numHashes; ++j)
+	{
+		AggStatePerHash perhash = &aggstate->perhash[j];
+		Bitmapset  *colnos = bms_copy(base_colnos);
+		AttrNumber *grpColIdx = perhash->aggnode->grpColIdx;
+		List	   *hashTlist = NIL;
+		TupleDesc	hashDesc;
+		int			maxCols;
+		int			i;
+
+		perhash->largestGrpColIdx = 0;
+
+		/*
+		 * If we're doing grouping sets, then some Vars might be referenced in
+		 * tlist/qual for the benefit of other grouping sets, but not needed
+		 * when hashing; i.e. prepare_projection_slot will null them out, so
+		 * there'd be no point storing them.  Use prepare_projection_slot's
+		 * logic to determine which.
+		 */
+		if (aggstate->phases[0].grouped_cols)
+		{
+			Bitmapset  *grouped_cols = aggstate->phases[0].grouped_cols[j];
+			ListCell   *lc;
+
+			foreach(lc, aggstate->all_grouped_cols)
+			{
+				int			attnum = lfirst_int(lc);
+
+				if (!bms_is_member(attnum, grouped_cols))
+					colnos = bms_del_member(colnos, attnum);
+			}
+		}
+
+		/*
+		 * Compute maximum number of input columns accounting for possible
+		 * duplications in the grpColIdx array, which can happen in some edge
+		 * cases where HashAggregate was generated as part of a semijoin or a
+		 * DISTINCT.
+		 */
+		maxCols = bms_num_members(colnos) + perhash->numCols;
+
+		perhash->hashGrpColIdxInput =
+			palloc(maxCols * sizeof(AttrNumber));
+		perhash->hashGrpColIdxHash =
+			palloc(perhash->numCols * sizeof(AttrNumber));
+
+		/* Add all the grouping columns to colnos */
+		for (i = 0; i < perhash->numCols; i++)
+			colnos = bms_add_member(colnos, grpColIdx[i]);
+
+		/*
+		 * First build mapping for columns directly hashed. These are the
+		 * first, because they'll be accessed when computing hash values and
+		 * comparing tuples for exact matches. We also build simple mapping
+		 * for execGrouping, so it knows where to find the to-be-hashed /
+		 * compared columns in the input.
+		 */
+		for (i = 0; i < perhash->numCols; i++)
+		{
+			perhash->hashGrpColIdxInput[i] = grpColIdx[i];
+			perhash->hashGrpColIdxHash[i] = i + 1;
+			perhash->numhashGrpCols++;
+			/* delete already mapped columns */
+			bms_del_member(colnos, grpColIdx[i]);
+		}
+
+		/* and add the remaining columns */
+		while ((i = bms_first_member(colnos)) >= 0)
+		{
+			perhash->hashGrpColIdxInput[perhash->numhashGrpCols] = i;
+			perhash->numhashGrpCols++;
+		}
+
+		/* and build a tuple descriptor for the hashtable */
+		for (i = 0; i < perhash->numhashGrpCols; i++)
+		{
+			int			varNumber = perhash->hashGrpColIdxInput[i] - 1;
+
+			hashTlist = lappend(hashTlist, list_nth(outerTlist, varNumber));
+			perhash->largestGrpColIdx =
+				Max(varNumber + 1, perhash->largestGrpColIdx);
+		}
+
+		hashDesc = ExecTypeFromTL(hashTlist);
+
+		execTuplesHashPrepare(perhash->numCols,
+							  perhash->aggnode->grpOperators,
+							  &perhash->eqfuncoids,
+							  &perhash->hashfunctions);
+		perhash->hashslot =
+			ExecAllocTableSlot(&estate->es_tupleTable, hashDesc,
+							   &TTSOpsMinimalTuple);
+
+		list_free(hashTlist);
+		bms_free(colnos);
+	}
+
+	bms_free(base_colnos);
+}
+
+/*
+ * Estimate per-hash-table-entry overhead.
+ */
+Size
+hash_agg_entry_size(int numTrans, Size tupleWidth, Size transitionSpace)
+{
+	Size		tupleChunkSize;
+	Size		pergroupChunkSize;
+	Size		transitionChunkSize;
+	Size		tupleSize = (MAXALIGN(SizeofMinimalTupleHeader) +
+							 tupleWidth);
+	Size		pergroupSize = numTrans * sizeof(AggStatePerGroupData);
+
+	tupleChunkSize = CHUNKHDRSZ + tupleSize;
+
+	if (pergroupSize > 0)
+		pergroupChunkSize = CHUNKHDRSZ + pergroupSize;
+	else
+		pergroupChunkSize = 0;
+
+	if (transitionSpace > 0)
+		transitionChunkSize = CHUNKHDRSZ + transitionSpace;
+	else
+		transitionChunkSize = 0;
+
+	return
+		sizeof(TupleHashEntryData) +
+		tupleChunkSize +
+		pergroupChunkSize +
+		transitionChunkSize;
+}
+
+/*
+ * hashagg_recompile_expressions()
+ *
+ * Identifies the right phase, compiles the right expression given the
+ * arguments, and then sets phase->evalfunc to that expression.
+ *
+ * Different versions of the compiled expression are needed depending on
+ * whether hash aggregation has spilled or not, and whether it's reading from
+ * the outer plan or a tape. Before spilling to disk, the expression reads
+ * from the outer plan and does not need to perform a NULL check. After
+ * HashAgg begins to spill, new groups will not be created in the hash table,
+ * and the AggStatePerGroup array may be NULL; therefore we need to add a null
+ * pointer check to the expression. Then, when reading spilled data from a
+ * tape, we change the outer slot type to be a fixed minimal tuple slot.
+ *
+ * It would be wasteful to recompile every time, so cache the compiled
+ * expressions in the AggStatePerPhase, and reuse when appropriate.
+ */
+static void
+hashagg_recompile_expressions(AggState *aggstate, bool minslot, bool nullcheck)
+{
+	AggStatePerPhase phase;
+	int			i = minslot ? 1 : 0;
+	int			j = nullcheck ? 1 : 0;
+
+	Assert(aggstate->aggstrategy == AGG_HASHED ||
+		   aggstate->aggstrategy == AGG_MIXED);
+
+	if (aggstate->aggstrategy == AGG_HASHED)
+		phase = &aggstate->phases[0];
+	else						/* AGG_MIXED */
+		phase = &aggstate->phases[1];
+
+	if (phase->evaltrans_cache[i][j] == NULL)
+	{
+		const TupleTableSlotOps *outerops = aggstate->ss.ps.outerops;
+		bool		outerfixed = aggstate->ss.ps.outeropsfixed;
+		bool		dohash = true;
+		bool		dosort = false;
+
+		/*
+		 * If minslot is true, that means we are processing a spilled batch
+		 * (inside agg_refill_hash_table()), and we must not advance the
+		 * sorted grouping sets.
+		 */
+		if (aggstate->aggstrategy == AGG_MIXED && !minslot)
+			dosort = true;
+
+		/* temporarily change the outerops while compiling the expression */
+		if (minslot)
+		{
+			aggstate->ss.ps.outerops = &TTSOpsMinimalTuple;
+			aggstate->ss.ps.outeropsfixed = true;
+		}
+
+		phase->evaltrans_cache[i][j] = ExecBuildAggTrans(aggstate, phase,
+														 dosort, dohash,
+														 nullcheck);
+
+		/* change back */
+		aggstate->ss.ps.outerops = outerops;
+		aggstate->ss.ps.outeropsfixed = outerfixed;
+	}
+
+	phase->evaltrans = phase->evaltrans_cache[i][j];
+}
+
+/*
+ * Set limits that trigger spilling to avoid exceeding hash_mem. Consider the
+ * number of partitions we expect to create (if we do spill).
+ *
+ * There are two limits: a memory limit, and also an ngroups limit. The
+ * ngroups limit becomes important when we expect transition values to grow
+ * substantially larger than the initial value.
+ */
+void
+hash_agg_set_limits(double hashentrysize, double input_groups, int used_bits,
+					Size *mem_limit, uint64 *ngroups_limit,
+					int *num_partitions)
+{
+	int			npartitions;
+	Size		partition_mem;
+	Size		hash_mem_limit = get_hash_memory_limit();
+
+	/* if not expected to spill, use all of hash_mem */
+	if (input_groups * hashentrysize <= hash_mem_limit)
+	{
+		if (num_partitions != NULL)
+			*num_partitions = 0;
+		*mem_limit = hash_mem_limit;
+		*ngroups_limit = hash_mem_limit / hashentrysize;
+		return;
+	}
+
+	/*
+	 * Calculate expected memory requirements for spilling, which is the size
+	 * of the buffers needed for all the tapes that need to be open at once.
+	 * Then, subtract that from the memory available for holding hash tables.
+	 */
+	npartitions = hash_choose_num_partitions(input_groups,
+											 hashentrysize,
+											 used_bits,
+											 NULL);
+	if (num_partitions != NULL)
+		*num_partitions = npartitions;
+
+	partition_mem =
+		HASHAGG_READ_BUFFER_SIZE +
+		HASHAGG_WRITE_BUFFER_SIZE * npartitions;
+
+	/*
+	 * Don't set the limit below 3/4 of hash_mem. In that case, we are at the
+	 * minimum number of partitions, so we aren't going to dramatically exceed
+	 * work mem anyway.
+	 */
+	if (hash_mem_limit > 4 * partition_mem)
+		*mem_limit = hash_mem_limit - partition_mem;
+	else
+		*mem_limit = hash_mem_limit * 0.75;
+
+	if (*mem_limit > hashentrysize)
+		*ngroups_limit = *mem_limit / hashentrysize;
+	else
+		*ngroups_limit = 1;
+}
+
+/*
+ * hash_agg_check_limits
+ *
+ * After adding a new group to the hash table, check whether we need to enter
+ * spill mode. Allocations may happen without adding new groups (for instance,
+ * if the transition state size grows), so this check is imperfect.
+ */
+static void
+hash_agg_check_limits(AggState *aggstate)
+{
+	uint64		ngroups = aggstate->hash_ngroups_current;
+	Size		meta_mem = MemoryContextMemAllocated(aggstate->hash_metacxt,
+													 true);
+	Size		hashkey_mem = MemoryContextMemAllocated(aggstate->hashcontext->ecxt_per_tuple_memory,
+														true);
+
+	/*
+	 * Don't spill unless there's at least one group in the hash table so we
+	 * can be sure to make progress even in edge cases.
+	 */
+	if (aggstate->hash_ngroups_current > 0 &&
+		(meta_mem + hashkey_mem > aggstate->hash_mem_limit ||
+		 ngroups > aggstate->hash_ngroups_limit))
+	{
+		hash_agg_enter_spill_mode(aggstate);
+	}
+}
+
+/*
+ * Enter "spill mode", meaning that no new groups are added to any of the hash
+ * tables. Tuples that would create a new group are instead spilled, and
+ * processed later.
+ */
+static void
+hash_agg_enter_spill_mode(AggState *aggstate)
+{
+	aggstate->hash_spill_mode = true;
+	hashagg_recompile_expressions(aggstate, aggstate->table_filled, true);
+
+	if (!aggstate->hash_ever_spilled)
+	{
+#if PG_VERSION_NUM < PG_VERSION_15
+		Assert(aggstate->hash_tapeinfo == NULL);
+#else
+		Assert(aggstate->hash_tapeset == NULL);
+#endif
+		Assert(aggstate->hash_spills == NULL);
+
+		aggstate->hash_ever_spilled = true;
+
+#if PG_VERSION_NUM < PG_VERSION_15
+		hashagg_tapeinfo_init(aggstate);
+#else
+		aggstate->hash_tapeset = LogicalTapeSetCreate(true, NULL, -1);
+#endif
+
+		aggstate->hash_spills = palloc(sizeof(HashAggSpill) * aggstate->num_hashes);
+
+		for (int setno = 0; setno < aggstate->num_hashes; setno++)
+		{
+			AggStatePerHash perhash = &aggstate->perhash[setno];
+			HashAggSpill *spill = &aggstate->hash_spills[setno];
+
+#if PG_VERSION_NUM < PG_VERSION_15
+			hashagg_spill_init(spill, aggstate->hash_tapeinfo, 0,
+#else
+			hashagg_spill_init(spill, aggstate->hash_tapeset, 0,
+#endif
+							   perhash->aggnode->numGroups,
+							   aggstate->hashentrysize);
+		}
+	}
+}
+
+/*
+ * Update metrics after filling the hash table.
+ *
+ * If reading from the outer plan, from_tape should be false; if reading from
+ * another tape, from_tape should be true.
+ */
+static void
+hash_agg_update_metrics(AggState *aggstate, bool from_tape, int npartitions)
+{
+	Size		meta_mem;
+	Size		hashkey_mem;
+	Size		buffer_mem;
+	Size		total_mem;
+
+	if (aggstate->aggstrategy != AGG_MIXED &&
+		aggstate->aggstrategy != AGG_HASHED)
+		return;
+
+	/* memory for the hash table itself */
+	meta_mem = MemoryContextMemAllocated(aggstate->hash_metacxt, true);
+
+	/* memory for the group keys and transition states */
+	hashkey_mem = MemoryContextMemAllocated(aggstate->hashcontext->ecxt_per_tuple_memory, true);
+
+	/* memory for read/write tape buffers, if spilled */
+	buffer_mem = npartitions * HASHAGG_WRITE_BUFFER_SIZE;
+	if (from_tape)
+		buffer_mem += HASHAGG_READ_BUFFER_SIZE;
+
+	/* update peak mem */
+	total_mem = meta_mem + hashkey_mem + buffer_mem;
+	if (total_mem > aggstate->hash_mem_peak)
+		aggstate->hash_mem_peak = total_mem;
+
+	/* update disk usage */
+#if PG_VERSION_NUM < PG_VERSION_15
+	if (aggstate->hash_tapeinfo != NULL)
+#else
+	if (aggstate->hash_tapeset != NULL)
+#endif
+	{
+#if PG_VERSION_NUM < PG_VERSION_15
+		uint64		disk_used = LogicalTapeSetBlocks(aggstate->hash_tapeinfo->tapeset) * (BLCKSZ / 1024);
+#else
+		uint64		disk_used = LogicalTapeSetBlocks(aggstate->hash_tapeset) * (BLCKSZ / 1024);
+#endif
+
+		if (aggstate->hash_disk_used < disk_used)
+			aggstate->hash_disk_used = disk_used;
+	}
+
+	/* update hashentrysize estimate based on contents */
+	if (aggstate->hash_ngroups_current > 0)
+	{
+		aggstate->hashentrysize =
+			sizeof(TupleHashEntryData) +
+			(hashkey_mem / (double) aggstate->hash_ngroups_current);
+	}
+}
+
+/*
+ * Choose a reasonable number of buckets for the initial hash table size.
+ */
+static long
+hash_choose_num_buckets(double hashentrysize, long ngroups, Size memory)
+{
+	long		max_nbuckets;
+	long		nbuckets = ngroups;
+
+	max_nbuckets = memory / hashentrysize;
+
+	/*
+	 * Underestimating is better than overestimating. Too many buckets crowd
+	 * out space for group keys and transition state values.
+	 */
+	max_nbuckets >>= 1;
+
+	if (nbuckets > max_nbuckets)
+		nbuckets = max_nbuckets;
+
+	return Max(nbuckets, 1);
+}
+
+/*
+ * Determine the number of partitions to create when spilling, which will
+ * always be a power of two. If log2_npartitions is non-NULL, set
+ * *log2_npartitions to the log2() of the number of partitions.
+ */
+static int
+hash_choose_num_partitions(double input_groups, double hashentrysize,
+						   int used_bits, int *log2_npartitions)
+{
+	Size		hash_mem_limit = get_hash_memory_limit();
+	double		partition_limit;
+	double		mem_wanted;
+	double		dpartitions;
+	int			npartitions;
+	int			partition_bits;
+
+	/*
+	 * Avoid creating so many partitions that the memory requirements of the
+	 * open partition files are greater than 1/4 of hash_mem.
+	 */
+	partition_limit =
+		(hash_mem_limit * 0.25 - HASHAGG_READ_BUFFER_SIZE) /
+		HASHAGG_WRITE_BUFFER_SIZE;
+
+	mem_wanted = HASHAGG_PARTITION_FACTOR * input_groups * hashentrysize;
+
+	/* make enough partitions so that each one is likely to fit in memory */
+	dpartitions = 1 + (mem_wanted / hash_mem_limit);
+
+	if (dpartitions > partition_limit)
+		dpartitions = partition_limit;
+
+	if (dpartitions < HASHAGG_MIN_PARTITIONS)
+		dpartitions = HASHAGG_MIN_PARTITIONS;
+	if (dpartitions > HASHAGG_MAX_PARTITIONS)
+		dpartitions = HASHAGG_MAX_PARTITIONS;
+
+	/* HASHAGG_MAX_PARTITIONS limit makes this safe */
+	npartitions = (int) dpartitions;
+
+	/* ceil(log2(npartitions)) */
+	partition_bits = my_log2(npartitions);
+
+	/* make sure that we don't exhaust the hash bits */
+	if (partition_bits + used_bits >= 32)
+		partition_bits = 32 - used_bits;
+
+	if (log2_npartitions != NULL)
+		*log2_npartitions = partition_bits;
+
+	/* number of partitions will be a power of two */
+	npartitions = 1 << partition_bits;
+
+	return npartitions;
+}
+
+/*
+ * Initialize a freshly-created TupleHashEntry.
+ */
+static void
+initialize_hash_entry(AggState *aggstate, TupleHashTable hashtable,
+					  TupleHashEntry entry)
+{
+	AggStatePerGroup pergroup;
+	int			transno;
+
+	aggstate->hash_ngroups_current++;
+	hash_agg_check_limits(aggstate);
+
+	/* no need to allocate or initialize per-group state */
+	if (aggstate->numtrans == 0)
+		return;
+
+	pergroup = (AggStatePerGroup)
+		MemoryContextAlloc(hashtable->tablecxt,
+						   sizeof(AggStatePerGroupData) * aggstate->numtrans);
+
+	entry->additional = pergroup;
+
+	/*
+	 * Initialize aggregates for new tuple group, lookup_hash_entries()
+	 * already has selected the relevant grouping set.
+	 */
+	for (transno = 0; transno < aggstate->numtrans; transno++)
+	{
+		AggStatePerTrans pertrans = &aggstate->pertrans[transno];
+		AggStatePerGroup pergroupstate = &pergroup[transno];
+
+		initialize_aggregate(aggstate, pertrans, pergroupstate);
+	}
+}
+
+/*
+ * Look up hash entries for the current tuple in all hashed grouping sets.
+ *
+ * Be aware that lookup_hash_entry can reset the tmpcontext.
+ *
+ * Some entries may be left NULL if we are in "spill mode". The same tuple
+ * will belong to different groups for each grouping set, so may match a group
+ * already in memory for one set and match a group not in memory for another
+ * set. When in "spill mode", the tuple will be spilled for each grouping set
+ * where it doesn't match a group in memory.
+ *
+ * NB: It's possible to spill the same tuple for several different grouping
+ * sets. This may seem wasteful, but it's actually a trade-off: if we spill
+ * the tuple multiple times for multiple grouping sets, it can be partitioned
+ * for each grouping set, making the refilling of the hash table very
+ * efficient.
+ */
+static void
+lookup_hash_entries(AggState *aggstate)
+{
+	AggStatePerGroup *pergroup = aggstate->hash_pergroup;
+	TupleTableSlot *outerslot = aggstate->tmpcontext->ecxt_outertuple;
+	int			setno;
+
+	for (setno = 0; setno < aggstate->num_hashes; setno++)
+	{
+		AggStatePerHash perhash = &aggstate->perhash[setno];
+		TupleHashTable hashtable = perhash->hashtable;
+		TupleTableSlot *hashslot = perhash->hashslot;
+		TupleHashEntry entry;
+		uint32		hash;
+		bool		isnew = false;
+		bool	   *p_isnew;
+
+		/* if hash table already spilled, don't create new entries */
+		p_isnew = aggstate->hash_spill_mode ? NULL : &isnew;
+
+		select_current_set(aggstate, setno, true);
+		prepare_hash_slot(perhash,
+						  outerslot,
+						  hashslot);
+
+		entry = LookupTupleHashEntry(hashtable, hashslot,
+									 p_isnew, &hash);
+
+		if (entry != NULL)
+		{
+			if (isnew)
+				initialize_hash_entry(aggstate, hashtable, entry);
+			pergroup[setno] = entry->additional;
+		}
+		else
+		{
+			HashAggSpill *spill = &aggstate->hash_spills[setno];
+			TupleTableSlot *slot = aggstate->tmpcontext->ecxt_outertuple;
+
+			if (spill->partitions == NULL)
+#if PG_VERSION_NUM < PG_VERSION_15
+				hashagg_spill_init(spill, aggstate->hash_tapeinfo, 0,
+#else
+				hashagg_spill_init(spill, aggstate->hash_tapeset, 0,
+#endif
+								   perhash->aggnode->numGroups,
+								   aggstate->hashentrysize);
+
+			hashagg_spill_tuple(aggstate, spill, slot, hash);
+			pergroup[setno] = NULL;
+		}
+	}
+}
+
+/*
+ * ExecAgg -
+ *
+ *	  ExecAgg receives tuples from its outer subplan and aggregates over
+ *	  the appropriate attribute for each aggregate function use (Aggref
+ *	  node) appearing in the targetlist or qual of the node.  The number
+ *	  of tuples to aggregate over depends on whether grouped or plain
+ *	  aggregation is selected.  In grouped aggregation, we produce a result
+ *	  row for each group; in plain aggregation there's a single result row
+ *	  for the whole query.  In either case, the value of each aggregate is
+ *	  stored in the expression context to be used when ExecProject evaluates
+ *	  the result tuple.
+ */
+static TupleTableSlot *
+ExecAgg(PlanState *pstate)
+{
+	VectorAggState *vectoraggstate = (VectorAggState *) pstate;
+	AggState *node = vectoraggstate->aggstate;
+	TupleTableSlot *result = NULL;
+
+	CHECK_FOR_INTERRUPTS();
+
+	if (!node->agg_done)
+	{
+		/* Dispatch based on strategy */
+		switch (node->phase->aggstrategy)
+		{
+			case AGG_HASHED:
+				if (!node->table_filled)
+					agg_fill_hash_table(node);
+				/* FALLTHROUGH */
+			case AGG_MIXED:
+				result = agg_retrieve_hash_table(node);
+				break;
+			case AGG_PLAIN:
+			case AGG_SORTED:
+				result = agg_retrieve_direct(vectoraggstate);
+				break;
+		}
+
+		if (!TupIsNull(result))
+			return result;
+	}
+
+	return NULL;
+}
+
+/*
+ * ExecAgg for non-hashed case
+ */
+static TupleTableSlot *
+agg_retrieve_direct(VectorAggState *vectoraggstate)
+{
+#if PG_VERSION_NUM < PG_VERSION_15
+	AggState 	*aggstate = vectoraggstate->aggstate;	
+#else
+	AggState *aggstate = vectoraggstate->aggstate;	
+#endif
+	Agg		   *node = aggstate->phase->aggnode;
+	ExprContext *econtext;
+	ExprContext *tmpcontext;
+	AggStatePerAgg peragg;
+	AggStatePerGroup *pergroups;
+	TupleTableSlot *outerslot = NULL;
+	TupleTableSlot *firstSlot;
+	TupleTableSlot *result;
+	bool		hasGroupingSets = aggstate->phase->numsets > 0;
+	int			numGroupingSets = Max(aggstate->phase->numsets, 1);
+	int			currentSet;
+	int			nextSetSize;
+	int			numReset;
+	int			i;
+
+	/*
+	 * get state info from node
+	 *
+	 * econtext is the per-output-tuple expression context
+	 *
+	 * tmpcontext is the per-input-tuple expression context
+	 */
+	econtext = aggstate->ss.ps.ps_ExprContext;
+	tmpcontext = aggstate->tmpcontext;
+
+	peragg = aggstate->peragg;
+	pergroups = aggstate->pergroups;
+	firstSlot = aggstate->ss.ss_ScanTupleSlot;
+
+	/*
+	 * We loop retrieving groups until we find one matching
+	 * aggstate->ss.ps.qual
+	 *
+	 * For grouping sets, we have the invariant that aggstate->projected_set
+	 * is either -1 (initial call) or the index (starting from 0) in
+	 * gset_lengths for the group we just completed (either by projecting a
+	 * row or by discarding it in the qual).
+	 */
+	while (!aggstate->agg_done)
+	{
+		/*
+		 * Clear the per-output-tuple context for each group, as well as
+		 * aggcontext (which contains any pass-by-ref transvalues of the old
+		 * group).  Some aggregate functions store working state in child
+		 * contexts; those now get reset automatically without us needing to
+		 * do anything special.
+		 *
+		 * We use ReScanExprContext not just ResetExprContext because we want
+		 * any registered shutdown callbacks to be called.  That allows
+		 * aggregate functions to ensure they've cleaned up any non-memory
+		 * resources.
+		 */
+		ReScanExprContext(econtext);
+
+		/*
+		 * Determine how many grouping sets need to be reset at this boundary.
+		 */
+		if (aggstate->projected_set >= 0 &&
+			aggstate->projected_set < numGroupingSets)
+			numReset = aggstate->projected_set + 1;
+		else
+			numReset = numGroupingSets;
+
+		/*
+		 * numReset can change on a phase boundary, but that's OK; we want to
+		 * reset the contexts used in _this_ phase, and later, after possibly
+		 * changing phase, initialize the right number of aggregates for the
+		 * _new_ phase.
+		 */
+
+		for (i = 0; i < numReset; i++)
+		{
+			ReScanExprContext(aggstate->aggcontexts[i]);
+		}
+
+		/*
+		 * Check if input is complete and there are no more groups to project
+		 * in this phase; move to next phase or mark as done.
+		 */
+		if (aggstate->input_done == true &&
+			aggstate->projected_set >= (numGroupingSets - 1))
+		{
+			if (aggstate->current_phase < aggstate->numphases - 1)
+			{
+				initialize_phase(aggstate, aggstate->current_phase + 1);
+				aggstate->input_done = false;
+				aggstate->projected_set = -1;
+				numGroupingSets = Max(aggstate->phase->numsets, 1);
+				node = aggstate->phase->aggnode;
+				numReset = numGroupingSets;
+			}
+			else if (aggstate->aggstrategy == AGG_MIXED)
+			{
+				/*
+				 * Mixed mode; we've output all the grouped stuff and have
+				 * full hashtables, so switch to outputting those.
+				 */
+				initialize_phase(aggstate, 0);
+				aggstate->table_filled = true;
+				ResetTupleHashIterator(aggstate->perhash[0].hashtable,
+									   &aggstate->perhash[0].hashiter);
+				select_current_set(aggstate, 0, true);
+				return agg_retrieve_hash_table(aggstate);
+			}
+			else
+			{
+				aggstate->agg_done = true;
+				break;
+			}
+		}
+
+		/*
+		 * Get the number of columns in the next grouping set after the last
+		 * projected one (if any). This is the number of columns to compare to
+		 * see if we reached the boundary of that set too.
+		 */
+		if (aggstate->projected_set >= 0 &&
+			aggstate->projected_set < (numGroupingSets - 1))
+			nextSetSize = aggstate->phase->gset_lengths[aggstate->projected_set + 1];
+		else
+			nextSetSize = 0;
+
+		/*----------
+		 * If a subgroup for the current grouping set is present, project it.
+		 *
+		 * We have a new group if:
+		 *	- we're out of input but haven't projected all grouping sets
+		 *	  (checked above)
+		 * OR
+		 *	  - we already projected a row that wasn't from the last grouping
+		 *		set
+		 *	  AND
+		 *	  - the next grouping set has at least one grouping column (since
+		 *		empty grouping sets project only once input is exhausted)
+		 *	  AND
+		 *	  - the previous and pending rows differ on the grouping columns
+		 *		of the next grouping set
+		 *----------
+		 */
+		tmpcontext->ecxt_innertuple = econtext->ecxt_outertuple;
+		if (aggstate->input_done ||
+			(node->aggstrategy != AGG_PLAIN &&
+			 aggstate->projected_set != -1 &&
+			 aggstate->projected_set < (numGroupingSets - 1) &&
+			 nextSetSize > 0 &&
+			 !ExecQualAndReset(aggstate->phase->eqfunctions[nextSetSize - 1],
+							   tmpcontext)))
+		{
+			aggstate->projected_set += 1;
+
+			Assert(aggstate->projected_set < numGroupingSets);
+			Assert(nextSetSize > 0 || aggstate->input_done);
+		}
+		else
+		{
+			/*
+			 * We no longer care what group we just projected, the next
+			 * projection will always be the first (or only) grouping set
+			 * (unless the input proves to be empty).
+			 */
+			aggstate->projected_set = 0;
+
+			/*
+			 * If we don't already have the first tuple of the new group,
+			 * fetch it from the outer plan.
+			 */
+			if (aggstate->grp_firstTuple == NULL)
+			{
+				outerslot = fetch_input_tuple(aggstate);
+				if (!TupIsNull(outerslot))
+				{
+					/*
+					 * Make a copy of the first input tuple; we will use this
+					 * for comparisons (in group mode) and for projection.
+					 */
+					aggstate->grp_firstTuple = ExecCopySlotHeapTuple(outerslot);
+				}
+				else
+				{
+					/* outer plan produced no tuples at all */
+					if (hasGroupingSets)
+					{
+						/*
+						 * If there was no input at all, we need to project
+						 * rows only if there are grouping sets of size 0.
+						 * Note that this implies that there can't be any
+						 * references to ungrouped Vars, which would otherwise
+						 * cause issues with the empty output slot.
+						 *
+						 * XXX: This is no longer true, we currently deal with
+						 * this in finalize_aggregates().
+						 */
+						aggstate->input_done = true;
+
+						while (aggstate->phase->gset_lengths[aggstate->projected_set] > 0)
+						{
+							aggstate->projected_set += 1;
+							if (aggstate->projected_set >= numGroupingSets)
+							{
+								/*
+								 * We can't set agg_done here because we might
+								 * have more phases to do, even though the
+								 * input is empty. So we need to restart the
+								 * whole outer loop.
+								 */
+								break;
+							}
+						}
+
+						if (aggstate->projected_set >= numGroupingSets)
+							continue;
+					}
+					else
+					{
+						aggstate->agg_done = true;
+						/* If we are grouping, we should produce no tuples too */
+						if (node->aggstrategy != AGG_PLAIN)
+							return NULL;
+					}
+				}
+			}
+
+			/*
+			 * Initialize working state for a new input tuple group.
+			 */
+			initialize_aggregates(aggstate, pergroups, numReset);
+
+			if (aggstate->grp_firstTuple != NULL)
+			{
+				/*
+				 * Store the copied first input tuple in the tuple table slot
+				 * reserved for it.  The tuple will be deleted when it is
+				 * cleared from the slot.
+				 */
+				ExecForceStoreHeapTuple(aggstate->grp_firstTuple,
+										firstSlot, true);
+				aggstate->grp_firstTuple = NULL;	/* don't keep two pointers */
+
+				/* set up for first advance_aggregates call */
+				tmpcontext->ecxt_outertuple = outerslot;
+
+				/*
+				 * Process each outer-plan tuple, and then fetch the next one,
+				 * until we exhaust the outer plan or cross a group boundary.
+				 */
+				for (;;)
+				{
+					/*
+					 * During phase 1 only of a mixed agg, we need to update
+					 * hashtables as well in advance_aggregates.
+					 */
+					if (aggstate->aggstrategy == AGG_MIXED &&
+						aggstate->current_phase == 1)
+					{
+						lookup_hash_entries(aggstate);
+					}
+
+					/* Advance the aggregates (or combine functions) */
+					advance_aggregates(aggstate);
+
+					int	transno;
+
+					currentSet = aggstate->projected_set;
+
+					prepare_projection_slot(aggstate, econtext->ecxt_outertuple, currentSet);
+
+					select_current_set(aggstate, currentSet, false);
+
+					for (transno = 0; transno < aggstate->numtrans; transno++)
+					{
+						AggStatePerTrans pertrans = &aggstate->pertrans[transno];
+						AggStatePerGroup pergroupstate;
+
+						pergroupstate = &pergroups[currentSet][transno];
+
+						// Should handle COUNT(*)
+						if (pertrans->aggref->aggstar)
+						{
+							int slotDim = ((VectorTupleTableSlot *)outerslot)->dimension;
+							pergroupstate->transValue += slotDim;
+						}
+					}
+
+					/* Reset per-input-tuple context after each tuple */
+					ResetExprContext(tmpcontext);
+
+					outerslot = fetch_input_tuple(aggstate);
+					if (TupIsNull(outerslot))
+					{
+						/* no more outer-plan tuples available */
+
+						/* if we built hash tables, finalize any spills */
+						if (aggstate->aggstrategy == AGG_MIXED &&
+							aggstate->current_phase == 1)
+							hashagg_finish_initial_spills(aggstate);
+
+						if (hasGroupingSets)
+						{
+							aggstate->input_done = true;
+							break;
+						}
+						else
+						{
+							aggstate->agg_done = true;
+							break;
+						}
+					}
+					/* set up for next advance_aggregates call */
+					tmpcontext->ecxt_outertuple = outerslot;
+
+					/*
+					 * If we are grouping, check whether we've crossed a group
+					 * boundary.
+					 */
+					if (node->aggstrategy != AGG_PLAIN)
+					{
+						tmpcontext->ecxt_innertuple = firstSlot;
+						if (!ExecQual(aggstate->phase->eqfunctions[node->numCols - 1],
+									  tmpcontext))
+						{
+							aggstate->grp_firstTuple = ExecCopySlotHeapTuple(outerslot);
+							break;
+						}
+					}
+				}
+			}
+
+			/*
+			 * Use the representative input tuple for any references to
+			 * non-aggregated input columns in aggregate direct args, the node
+			 * qual, and the tlist.  (If we are not grouping, and there are no
+			 * input rows at all, we will come here with an empty firstSlot
+			 * ... but if not grouping, there can't be any references to
+			 * non-aggregated input columns, so no problem.)
+			 */
+			econtext->ecxt_outertuple = firstSlot;
+		}
+
+		Assert(aggstate->projected_set >= 0);
+
+		currentSet = aggstate->projected_set;
+
+		prepare_projection_slot(aggstate, econtext->ecxt_outertuple, currentSet);
+
+		select_current_set(aggstate, currentSet, false);
+
+		finalize_aggregates(aggstate,
+							peragg,
+							pergroups[currentSet]);
+
+		/*
+		 * If there's no row to project right now, we must continue rather
+		 * than returning a null since there might be more groups.
+		 */
+		result = project_aggregates(aggstate);
+		if (result)
+			return result;
+	}
+
+	/* No more groups */
+	return NULL;
+}
+
+/*
+ * ExecAgg for hashed case: read input and build hash table
+ */
+static void
+agg_fill_hash_table(AggState *aggstate)
+{
+	TupleTableSlot *outerslot;
+	ExprContext *tmpcontext = aggstate->tmpcontext;
+
+	/*
+	 * Process each outer-plan tuple, and then fetch the next one, until we
+	 * exhaust the outer plan.
+	 */
+	for (;;)
+	{
+		outerslot = fetch_input_tuple(aggstate);
+		if (TupIsNull(outerslot))
+			break;
+
+		/* set up for lookup_hash_entries and advance_aggregates */
+		tmpcontext->ecxt_outertuple = outerslot;
+
+		/* Find or build hashtable entries */
+		lookup_hash_entries(aggstate);
+
+		/* Advance the aggregates (or combine functions) */
+		advance_aggregates(aggstate);
+
+		/*
+		 * Reset per-input-tuple context after each tuple, but note that the
+		 * hash lookups do this too
+		 */
+		ResetExprContext(aggstate->tmpcontext);
+	}
+
+	/* finalize spills, if any */
+	hashagg_finish_initial_spills(aggstate);
+
+	aggstate->table_filled = true;
+	/* Initialize to walk the first hash table */
+	select_current_set(aggstate, 0, true);
+	ResetTupleHashIterator(aggstate->perhash[0].hashtable,
+						   &aggstate->perhash[0].hashiter);
+}
+
+/*
+ * If any data was spilled during hash aggregation, reset the hash table and
+ * reprocess one batch of spilled data. After reprocessing a batch, the hash
+ * table will again contain data, ready to be consumed by
+ * agg_retrieve_hash_table_in_memory().
+ *
+ * Should only be called after all in memory hash table entries have been
+ * finalized and emitted.
+ *
+ * Return false when input is exhausted and there's no more work to be done;
+ * otherwise return true.
+ */
+static bool
+agg_refill_hash_table(AggState *aggstate)
+{
+	HashAggBatch *batch;
+	AggStatePerHash perhash;
+	HashAggSpill spill;
+#if PG_VERSION_NUM < PG_VERSION_15
+	HashTapeInfo *tapeinfo = aggstate->hash_tapeinfo;
+#else
+	LogicalTapeSet *tapeset = aggstate->hash_tapeset;
+#endif
+	bool		spill_initialized = false;
+
+	if (aggstate->hash_batches == NIL)
+		return false;
+
+	/* hash_batches is a stack, with the top item at the end of the list */
+	batch = llast(aggstate->hash_batches);
+	aggstate->hash_batches = list_delete_last(aggstate->hash_batches);
+
+	hash_agg_set_limits(aggstate->hashentrysize, batch->input_card,
+						batch->used_bits, &aggstate->hash_mem_limit,
+						&aggstate->hash_ngroups_limit, NULL);
+
+	/*
+	 * Each batch only processes one grouping set; set the rest to NULL so
+	 * that advance_aggregates() knows to ignore them. We don't touch
+	 * pergroups for sorted grouping sets here, because they will be needed if
+	 * we rescan later. The expressions for sorted grouping sets will not be
+	 * evaluated after we recompile anyway.
+	 */
+	MemSet(aggstate->hash_pergroup, 0,
+		   sizeof(AggStatePerGroup) * aggstate->num_hashes);
+
+	/* free memory and reset hash tables */
+	ReScanExprContext(aggstate->hashcontext);
+	for (int setno = 0; setno < aggstate->num_hashes; setno++)
+		ResetTupleHashTable(aggstate->perhash[setno].hashtable);
+
+	aggstate->hash_ngroups_current = 0;
+
+	/*
+	 * In AGG_MIXED mode, hash aggregation happens in phase 1 and the output
+	 * happens in phase 0. So, we switch to phase 1 when processing a batch,
+	 * and back to phase 0 after the batch is done.
+	 */
+	Assert(aggstate->current_phase == 0);
+	if (aggstate->phase->aggstrategy == AGG_MIXED)
+	{
+		aggstate->current_phase = 1;
+		aggstate->phase = &aggstate->phases[aggstate->current_phase];
+	}
+
+	select_current_set(aggstate, batch->setno, true);
+
+	perhash = &aggstate->perhash[aggstate->current_set];
+
+	/*
+	 * Spilled tuples are always read back as MinimalTuples, which may be
+	 * different from the outer plan, so recompile the aggregate expressions.
+	 *
+	 * We still need the NULL check, because we are only processing one
+	 * grouping set at a time and the rest will be NULL.
+	 */
+	hashagg_recompile_expressions(aggstate, true, true);
+
+	for (;;)
+	{
+		TupleTableSlot *spillslot = aggstate->hash_spill_rslot;
+		TupleTableSlot *hashslot = perhash->hashslot;
+		TupleHashEntry entry;
+		MinimalTuple tuple;
+		uint32		hash;
+		bool		isnew = false;
+		bool	   *p_isnew = aggstate->hash_spill_mode ? NULL : &isnew;
+
+		CHECK_FOR_INTERRUPTS();
+
+		tuple = hashagg_batch_read(batch, &hash);
+		if (tuple == NULL)
+			break;
+
+		ExecStoreMinimalTuple(tuple, spillslot, true);
+		aggstate->tmpcontext->ecxt_outertuple = spillslot;
+
+		prepare_hash_slot(perhash,
+						  aggstate->tmpcontext->ecxt_outertuple,
+						  hashslot);
+#if PG_VERSION_NUM < PG_VERSION_15
+		entry = LookupTupleHashEntryHash(
+										 perhash->hashtable, hashslot, p_isnew, hash);
+#else
+		entry = LookupTupleHashEntryHash(perhash->hashtable, hashslot,
+										 p_isnew, hash);
+#endif
+
+		if (entry != NULL)
+		{
+			if (isnew)
+				initialize_hash_entry(aggstate, perhash->hashtable, entry);
+			aggstate->hash_pergroup[batch->setno] = entry->additional;
+			advance_aggregates(aggstate);
+		}
+		else
+		{
+			if (!spill_initialized)
+			{
+				/*
+				 * Avoid initializing the spill until we actually need it so
+				 * that we don't assign tapes that will never be used.
+				 */
+				spill_initialized = true;
+#if PG_VERSION_NUM < PG_VERSION_15
+				hashagg_spill_init(&spill, tapeinfo, batch->used_bits,
+#else
+				hashagg_spill_init(&spill, tapeset, batch->used_bits,
+#endif
+								   batch->input_card, aggstate->hashentrysize);
+			}
+			/* no memory for a new group, spill */
+			hashagg_spill_tuple(aggstate, &spill, spillslot, hash);
+
+			aggstate->hash_pergroup[batch->setno] = NULL;
+		}
+
+		/*
+		 * Reset per-input-tuple context after each tuple, but note that the
+		 * hash lookups do this too
+		 */
+		ResetExprContext(aggstate->tmpcontext);
+	}
+
+#if PG_VERSION_NUM < PG_VERSION_15
+	hashagg_tapeinfo_release(tapeinfo, batch->input_tapenum);
+#else
+	LogicalTapeClose(batch->input_tape);
+#endif
+
+	/* change back to phase 0 */
+	aggstate->current_phase = 0;
+	aggstate->phase = &aggstate->phases[aggstate->current_phase];
+
+	if (spill_initialized)
+	{
+		hashagg_spill_finish(aggstate, &spill, batch->setno);
+		hash_agg_update_metrics(aggstate, true, spill.npartitions);
+	}
+	else
+		hash_agg_update_metrics(aggstate, true, 0);
+
+	aggstate->hash_spill_mode = false;
+
+	/* prepare to walk the first hash table */
+	select_current_set(aggstate, batch->setno, true);
+	ResetTupleHashIterator(aggstate->perhash[batch->setno].hashtable,
+						   &aggstate->perhash[batch->setno].hashiter);
+
+	pfree(batch);
+
+	return true;
+}
+
+/*
+ * ExecAgg for hashed case: retrieving groups from hash table
+ *
+ * After exhausting in-memory tuples, also try refilling the hash table using
+ * previously-spilled tuples. Only returns NULL after all in-memory and
+ * spilled tuples are exhausted.
+ */
+static TupleTableSlot *
+agg_retrieve_hash_table(AggState *aggstate)
+{
+	TupleTableSlot *result = NULL;
+
+	while (result == NULL)
+	{
+		result = agg_retrieve_hash_table_in_memory(aggstate);
+		if (result == NULL)
+		{
+			if (!agg_refill_hash_table(aggstate))
+			{
+				aggstate->agg_done = true;
+				break;
+			}
+		}
+	}
+
+	return result;
+}
+
+/*
+ * Retrieve the groups from the in-memory hash tables without considering any
+ * spilled tuples.
+ */
+static TupleTableSlot *
+agg_retrieve_hash_table_in_memory(AggState *aggstate)
+{
+	ExprContext *econtext;
+	AggStatePerAgg peragg;
+	AggStatePerGroup pergroup;
+	TupleHashEntryData *entry;
+	TupleTableSlot *firstSlot;
+	TupleTableSlot *result;
+	AggStatePerHash perhash;
+
+	/*
+	 * get state info from node.
+	 *
+	 * econtext is the per-output-tuple expression context.
+	 */
+	econtext = aggstate->ss.ps.ps_ExprContext;
+	peragg = aggstate->peragg;
+	firstSlot = aggstate->ss.ss_ScanTupleSlot;
+
+	/*
+	 * Note that perhash (and therefore anything accessed through it) can
+	 * change inside the loop, as we change between grouping sets.
+	 */
+	perhash = &aggstate->perhash[aggstate->current_set];
+
+	/*
+	 * We loop retrieving groups until we find one satisfying
+	 * aggstate->ss.ps.qual
+	 */
+	for (;;)
+	{
+		TupleTableSlot *hashslot = perhash->hashslot;
+		int			i;
+
+		CHECK_FOR_INTERRUPTS();
+
+		/*
+		 * Find the next entry in the hash table
+		 */
+		entry = ScanTupleHashTable(perhash->hashtable, &perhash->hashiter);
+		if (entry == NULL)
+		{
+			int			nextset = aggstate->current_set + 1;
+
+			if (nextset < aggstate->num_hashes)
+			{
+				/*
+				 * Switch to next grouping set, reinitialize, and restart the
+				 * loop.
+				 */
+				select_current_set(aggstate, nextset, true);
+
+				perhash = &aggstate->perhash[aggstate->current_set];
+
+				ResetTupleHashIterator(perhash->hashtable, &perhash->hashiter);
+
+				continue;
+			}
+			else
+			{
+				return NULL;
+			}
+		}
+
+		/*
+		 * Clear the per-output-tuple context for each group
+		 *
+		 * We intentionally don't use ReScanExprContext here; if any aggs have
+		 * registered shutdown callbacks, they mustn't be called yet, since we
+		 * might not be done with that agg.
+		 */
+		ResetExprContext(econtext);
+
+		/*
+		 * Transform representative tuple back into one with the right
+		 * columns.
+		 */
+		ExecStoreMinimalTuple(entry->firstTuple, hashslot, false);
+		slot_getallattrs(hashslot);
+
+		ExecClearTuple(firstSlot);
+		memset(firstSlot->tts_isnull, true,
+			   firstSlot->tts_tupleDescriptor->natts * sizeof(bool));
+
+		for (i = 0; i < perhash->numhashGrpCols; i++)
+		{
+			int			varNumber = perhash->hashGrpColIdxInput[i] - 1;
+
+			firstSlot->tts_values[varNumber] = hashslot->tts_values[i];
+			firstSlot->tts_isnull[varNumber] = hashslot->tts_isnull[i];
+		}
+		ExecStoreVirtualTuple(firstSlot);
+
+		pergroup = (AggStatePerGroup) entry->additional;
+
+		/*
+		 * Use the representative input tuple for any references to
+		 * non-aggregated input columns in the qual and tlist.
+		 */
+		econtext->ecxt_outertuple = firstSlot;
+
+		prepare_projection_slot(aggstate,
+								econtext->ecxt_outertuple,
+								aggstate->current_set);
+
+		finalize_aggregates(aggstate, peragg, pergroup);
+
+		result = project_aggregates(aggstate);
+		if (result)
+			return result;
+	}
+
+	/* No more groups */
+	return NULL;
+}
+
+#if PG_VERSION_NUM < PG_VERSION_15
+/*
+ * Initialize HashTapeInfo
+ */
+static void
+hashagg_tapeinfo_init(AggState *aggstate)
+{
+	HashTapeInfo *tapeinfo = palloc(sizeof(HashTapeInfo));
+	int			init_tapes = 16;	/* expanded dynamically */
+
+	tapeinfo->tapeset = LogicalTapeSetCreate(init_tapes, true, NULL, NULL, -1);
+	tapeinfo->ntapes = init_tapes;
+	tapeinfo->nfreetapes = init_tapes;
+	tapeinfo->freetapes_alloc = init_tapes;
+	tapeinfo->freetapes = palloc(init_tapes * sizeof(int));
+	for (int i = 0; i < init_tapes; i++)
+		tapeinfo->freetapes[i] = i;
+
+	aggstate->hash_tapeinfo = tapeinfo;
+}
+
+/*
+ * Assign unused tapes to spill partitions, extending the tape set if
+ * necessary.
+ */
+static void
+hashagg_tapeinfo_assign(HashTapeInfo *tapeinfo, int *partitions,
+						int npartitions)
+{
+	int			partidx = 0;
+
+	/* use free tapes if available */
+	while (partidx < npartitions && tapeinfo->nfreetapes > 0)
+		partitions[partidx++] = tapeinfo->freetapes[--tapeinfo->nfreetapes];
+
+	if (partidx < npartitions)
+	{
+		LogicalTapeSetExtend(tapeinfo->tapeset, npartitions - partidx);
+
+		while (partidx < npartitions)
+			partitions[partidx++] = tapeinfo->ntapes++;
+	}
+}
+
+/*
+ * After a tape has already been written to and then read, this function
+ * rewinds it for writing and adds it to the free list.
+ */
+static void
+hashagg_tapeinfo_release(HashTapeInfo *tapeinfo, int tapenum)
+{
+	/* rewinding frees the buffer while not in use */
+	LogicalTapeRewindForWrite(tapeinfo->tapeset, tapenum);
+	if (tapeinfo->freetapes_alloc == tapeinfo->nfreetapes)
+	{
+		tapeinfo->freetapes_alloc <<= 1;
+		tapeinfo->freetapes = repalloc(tapeinfo->freetapes,
+									   tapeinfo->freetapes_alloc * sizeof(int));
+	}
+	tapeinfo->freetapes[tapeinfo->nfreetapes++] = tapenum;
+}
+#endif
+
+/*
+ * hashagg_spill_init
+ *
+ * Called after we determined that spilling is necessary. Chooses the number
+ * of partitions to create, and initializes them.
+ */
+static void
+#if PG_VERSION_NUM < PG_VERSION_15
+hashagg_spill_init(HashAggSpill *spill, HashTapeInfo *tapeinfo, int used_bits,
+#else
+hashagg_spill_init(HashAggSpill *spill, LogicalTapeSet *tapeset, int used_bits,
+#endif
+				   double input_groups, double hashentrysize)
+{
+	int			npartitions;
+	int			partition_bits;
+
+	npartitions = hash_choose_num_partitions(input_groups, hashentrysize,
+											 used_bits, &partition_bits);
+
+#if PG_VERSION_NUM < PG_VERSION_15
+	spill->partitions = palloc0(sizeof(int) * npartitions);
+#else
+	spill->partitions = palloc0(sizeof(LogicalTape *) * npartitions);
+#endif
+	spill->ntuples = palloc0(sizeof(int64) * npartitions);
+	spill->hll_card = palloc0(sizeof(hyperLogLogState) * npartitions);
+
+#if PG_VERSION_NUM <= PG_VERSION_15
+	hashagg_tapeinfo_assign(tapeinfo, spill->partitions, npartitions);
+#else
+	for (int i = 0; i < npartitions; i++)
+		spill->partitions[i] = LogicalTapeCreate(tapeset);
+#endif
+
+#if PG_VERSION_NUM < PG_VERSION_15
+	spill->tapeset = tapeinfo->tapeset;
+#endif
+	spill->shift = 32 - used_bits - partition_bits;
+	spill->mask = (npartitions - 1) << spill->shift;
+	spill->npartitions = npartitions;
+
+	for (int i = 0; i < npartitions; i++)
+		initHyperLogLog(&spill->hll_card[i], HASHAGG_HLL_BIT_WIDTH);
+}
+
+/*
+ * hashagg_spill_tuple
+ *
+ * No room for new groups in the hash table. Save for later in the appropriate
+ * partition.
+ */
+static Size
+hashagg_spill_tuple(AggState *aggstate, HashAggSpill *spill,
+					TupleTableSlot *inputslot, uint32 hash)
+{
+#if PG_VERSION_NUM <= PG_VERSION_15
+	LogicalTapeSet *tapeset = spill->tapeset;
+#endif
+	TupleTableSlot *spillslot;
+	int			partition;
+	MinimalTuple tuple;
+#if PG_VERSION_NUM < PG_VERSION_15
+	int			tapenum;
+#else
+	LogicalTape *tape;
+#endif
+	int			total_written = 0;
+	bool		shouldFree;
+
+	Assert(spill->partitions != NULL);
+
+	/* spill only attributes that we actually need */
+	if (!aggstate->all_cols_needed)
+	{
+		spillslot = aggstate->hash_spill_wslot;
+		slot_getsomeattrs(inputslot, aggstate->max_colno_needed);
+		ExecClearTuple(spillslot);
+		for (int i = 0; i < spillslot->tts_tupleDescriptor->natts; i++)
+		{
+			if (bms_is_member(i + 1, aggstate->colnos_needed))
+			{
+				spillslot->tts_values[i] = inputslot->tts_values[i];
+				spillslot->tts_isnull[i] = inputslot->tts_isnull[i];
+			}
+			else
+				spillslot->tts_isnull[i] = true;
+		}
+		ExecStoreVirtualTuple(spillslot);
+	}
+	else
+		spillslot = inputslot;
+
+	tuple = ExecFetchSlotMinimalTuple(spillslot, &shouldFree);
+
+	partition = (hash & spill->mask) >> spill->shift;
+	spill->ntuples[partition]++;
+
+	/*
+	 * All hash values destined for a given partition have some bits in
+	 * common, which causes bad HLL cardinality estimates. Hash the hash to
+	 * get a more uniform distribution.
+	 */
+	addHyperLogLog(&spill->hll_card[partition], hash_bytes_uint32(hash));
+
+#if PG_VERSION_NUM <= PG_VERSION_15
+	tapenum = spill->partitions[partition];
+#else
+	tape = spill->partitions[partition];
+#endif
+
+#if PG_VERSION_NUM < PG_VERSION_15
+	LogicalTapeWrite(tapeset, tapenum, (void *) &hash, sizeof(uint32));
+#else
+	LogicalTapeWrite(tape, (void *) &hash, sizeof(uint32));
+#endif
+	total_written += sizeof(uint32);
+
+#if PG_VERSION_NUM < PG_VERSION_15
+	LogicalTapeWrite(tapeset, tapenum, (void *) tuple, tuple->t_len);
+#else
+	LogicalTapeWrite(tape, (void *) tuple, tuple->t_len);
+#endif
+	total_written += tuple->t_len;
+
+	if (shouldFree)
+		pfree(tuple);
+
+	return total_written;
+}
+
+/*
+ * hashagg_batch_new
+ *
+ * Construct a HashAggBatch item, which represents one iteration of HashAgg to
+ * be done.
+ */
+static HashAggBatch *
+#if PG_VERSION_NUM < PG_VERSION_15
+hashagg_batch_new(LogicalTapeSet *tapeset, int tapenum, int setno,
+#else
+hashagg_batch_new(LogicalTape *input_tape, int setno,
+#endif
+				  int64 input_tuples, double input_card, int used_bits)
+{
+	HashAggBatch *batch = palloc0(sizeof(HashAggBatch));
+
+	batch->setno = setno;
+	batch->used_bits = used_bits;
+#if PG_VERSION_NUM < PG_VERSION_15
+	batch->tapeset = tapeset;
+	batch->input_tapenum = tapenum;
+#else
+	batch->input_tape = input_tape;
+#endif
+	batch->input_tuples = input_tuples;
+	batch->input_card = input_card;
+
+	return batch;
+}
+
+/*
+ * read_spilled_tuple
+ * 		read the next tuple from a batch's tape.  Return NULL if no more.
+ */
+static MinimalTuple
+hashagg_batch_read(HashAggBatch *batch, uint32 *hashp)
+{
+#if PG_VERSION_NUM < PG_VERSION_15
+	LogicalTapeSet *tapeset = batch->tapeset;
+	int			tapenum = batch->input_tapenum;
+#else
+	LogicalTape *tape = batch->input_tape;
+#endif
+	MinimalTuple tuple;
+	uint32		t_len;
+	size_t		nread;
+	uint32		hash;
+
+#if PG_VERSION_NUM < PG_VERSION_15
+	nread = LogicalTapeRead(tapeset, tapenum, &hash, sizeof(uint32));
+#else
+	nread = LogicalTapeRead(tape, &hash, sizeof(uint32));
+#endif
+	if (nread == 0)
+		return NULL;
+	if (nread != sizeof(uint32))
+		ereport(ERROR,
+				(errcode_for_file_access(),
+#if PG_VERSION_NUM < PG_VERSION_15
+				 errmsg("unexpected EOF for tape %d: requested %zu bytes, read %zu bytes",
+						tapenum, sizeof(uint32), nread)));
+#else
+				 errmsg_internal("unexpected EOF for tape %p: requested %zu bytes, read %zu bytes",
+								 tape, sizeof(uint32), nread)));
+#endif
+	if (hashp != NULL)
+		*hashp = hash;
+
+#if PG_VERSION_NUM < PG_VERSION_15
+	nread = LogicalTapeRead(tapeset, tapenum, &t_len, sizeof(t_len));
+#else
+	nread = LogicalTapeRead(tape, &t_len, sizeof(t_len));
+#endif
+	if (nread != sizeof(uint32))
+		ereport(ERROR,
+				(errcode_for_file_access(),
+#if PG_VERSION_NUM < PG_VERSION_15
+				 errmsg("unexpected EOF for tape %d: requested %zu bytes, read %zu bytes",
+						tapenum, sizeof(uint32), nread)));
+#else
+				 errmsg_internal("unexpected EOF for tape %p: requested %zu bytes, read %zu bytes",
+								 tape, sizeof(uint32), nread)));
+#endif
+
+	tuple = (MinimalTuple) palloc(t_len);
+	tuple->t_len = t_len;
+
+#if PG_VERSION_NUM < PG_VERSION_15
+	nread = LogicalTapeRead(tapeset, tapenum,
+#else
+	nread = LogicalTapeRead(tape,
+#endif
+							(void *) ((char *) tuple + sizeof(uint32)),
+							t_len - sizeof(uint32));
+	if (nread != t_len - sizeof(uint32))
+		ereport(ERROR,
+				(errcode_for_file_access(),
+#if PG_VERSION_NUM < PG_VERSION_15
+				 errmsg("unexpected EOF for tape %d: requested %zu bytes, read %zu bytes",
+						tapenum, t_len - sizeof(uint32), nread)));
+#else
+				 errmsg_internal("unexpected EOF for tape %p: requested %zu bytes, read %zu bytes",
+								 tape, t_len - sizeof(uint32), nread)));
+#endif
+
+	return tuple;
+}
+
+/*
+ * hashagg_finish_initial_spills
+ *
+ * After a HashAggBatch has been processed, it may have spilled tuples to
+ * disk. If so, turn the spilled partitions into new batches that must later
+ * be executed.
+ */
+static void
+hashagg_finish_initial_spills(AggState *aggstate)
+{
+	int			setno;
+	int			total_npartitions = 0;
+
+	if (aggstate->hash_spills != NULL)
+	{
+		for (setno = 0; setno < aggstate->num_hashes; setno++)
+		{
+			HashAggSpill *spill = &aggstate->hash_spills[setno];
+
+			total_npartitions += spill->npartitions;
+			hashagg_spill_finish(aggstate, spill, setno);
+		}
+
+		/*
+		 * We're not processing tuples from outer plan any more; only
+		 * processing batches of spilled tuples. The initial spill structures
+		 * are no longer needed.
+		 */
+		pfree(aggstate->hash_spills);
+		aggstate->hash_spills = NULL;
+	}
+
+	hash_agg_update_metrics(aggstate, false, total_npartitions);
+	aggstate->hash_spill_mode = false;
+}
+
+/*
+ * hashagg_spill_finish
+ *
+ * Transform spill partitions into new batches.
+ */
+static void
+hashagg_spill_finish(AggState *aggstate, HashAggSpill *spill, int setno)
+{
+	int			i;
+	int			used_bits = 32 - spill->shift;
+
+	if (spill->npartitions == 0)
+		return;					/* didn't spill */
+
+	for (i = 0; i < spill->npartitions; i++)
+	{
+#if PG_VERSION_NUM < PG_VERSION_15
+		LogicalTapeSet *tapeset = aggstate->hash_tapeinfo->tapeset;
+		int			tapenum = spill->partitions[i];
+#else
+		LogicalTape *tape = spill->partitions[i];
+#endif
+		HashAggBatch *new_batch;
+		double		cardinality;
+
+		/* if the partition is empty, don't create a new batch of work */
+		if (spill->ntuples[i] == 0)
+			continue;
+
+		cardinality = estimateHyperLogLog(&spill->hll_card[i]);
+		freeHyperLogLog(&spill->hll_card[i]);
+
+		/* rewinding frees the buffer while not in use */
+#if PG_VERSION_NUM < PG_VERSION_15
+		LogicalTapeRewindForRead(tapeset, tapenum,
+								 HASHAGG_READ_BUFFER_SIZE);
+#else
+		LogicalTapeRewindForRead(tape, HASHAGG_READ_BUFFER_SIZE);
+#endif
+
+#if PG_VERSION_NUM < PG_VERSION_15
+		new_batch = hashagg_batch_new(tapeset, tapenum, setno,
+#else
+		new_batch = hashagg_batch_new(tape, setno,
+#endif
+									  spill->ntuples[i], cardinality,
+									  used_bits);
+		aggstate->hash_batches = lappend(aggstate->hash_batches, new_batch);
+		aggstate->hash_batches_used++;
+	}
+
+	pfree(spill->ntuples);
+	pfree(spill->hll_card);
+	pfree(spill->partitions);
+}
+
+/*
+ * Free resources related to a spilled HashAgg.
+ */
+static void
+hashagg_reset_spill_state(AggState *aggstate)
+{
+	/* free spills from initial pass */
+	if (aggstate->hash_spills != NULL)
+	{
+		int			setno;
+
+		for (setno = 0; setno < aggstate->num_hashes; setno++)
+		{
+			HashAggSpill *spill = &aggstate->hash_spills[setno];
+
+			pfree(spill->ntuples);
+			pfree(spill->partitions);
+		}
+		pfree(aggstate->hash_spills);
+		aggstate->hash_spills = NULL;
+	}
+
+	/* free batches */
+	list_free_deep(aggstate->hash_batches);
+	aggstate->hash_batches = NIL;
+
+	/* close tape set */
+#if PG_VERSION_NUM < PG_VERSION_15
+	if (aggstate->hash_tapeinfo != NULL)
+#else
+	if (aggstate->hash_tapeset != NULL)
+#endif
+	{
+#if PG_VERSION_NUM < PG_VERSION_15
+		HashTapeInfo *tapeinfo = aggstate->hash_tapeinfo;
+
+		LogicalTapeSetClose(tapeinfo->tapeset);
+		pfree(tapeinfo->freetapes);
+		pfree(tapeinfo);
+		aggstate->hash_tapeinfo = NULL;
+#else 
+		LogicalTapeSetClose(aggstate->hash_tapeset);
+		aggstate->hash_tapeset = NULL;
+#endif
+	}
+}
+
+
+/* -----------------
+ * VExecInitAgg
+ *
+ *	Creates the run-time information for the agg node produced by the
+ *	planner and initializes its outer subtree.
+ *
+ * -----------------
+ */
+static AggState *
+VExecInitAgg(Agg *node, EState *estate, int eflags)
+{
+	AggState   *aggstate;
+	AggStatePerAgg peraggs;
+	AggStatePerTrans pertransstates;
+	AggStatePerGroup *pergroups;
+	Plan	   *outerPlan;
+	ExprContext *econtext;
+	TupleDesc	scanDesc;
+	int			max_aggno;
+	int			max_transno;
+	int			numaggrefs;
+	int			numaggs;
+	int			numtrans;
+	int			phase;
+	int			phaseidx;
+	ListCell   *l;
+	Bitmapset  *all_grouped_cols = NULL;
+	int			numGroupingSets = 1;
+	int			numPhases;
+	int			numHashes;
+	int			i = 0;
+	int			j = 0;
+	bool		use_hashing = (node->aggstrategy == AGG_HASHED ||
+							   node->aggstrategy == AGG_MIXED);
+
+	/* check for unsupported flags */
+	Assert(!(eflags & (EXEC_FLAG_BACKWARD | EXEC_FLAG_MARK)));
+
+	/*
+	 * create state structure
+	 */
+	aggstate = makeNode(AggState);
+	aggstate->ss.ps.plan = (Plan *) node;
+	aggstate->ss.ps.state = estate;
+	aggstate->ss.ps.ExecProcNode = ExecAgg;
+
+	aggstate->aggs = NIL;
+	aggstate->numaggs = 0;
+	aggstate->numtrans = 0;
+	aggstate->aggstrategy = node->aggstrategy;
+	aggstate->aggsplit = node->aggsplit;
+	aggstate->maxsets = 0;
+	aggstate->projected_set = -1;
+	aggstate->current_set = 0;
+	aggstate->peragg = NULL;
+	aggstate->pertrans = NULL;
+	aggstate->curperagg = NULL;
+	aggstate->curpertrans = NULL;
+	aggstate->input_done = false;
+	aggstate->agg_done = false;
+	aggstate->pergroups = NULL;
+	aggstate->grp_firstTuple = NULL;
+	aggstate->sort_in = NULL;
+	aggstate->sort_out = NULL;
+
+	/*
+	 * phases[0] always exists, but is dummy in sorted/plain mode
+	 */
+	numPhases = (use_hashing ? 1 : 2);
+	numHashes = (use_hashing ? 1 : 0);
+
+	/*
+	 * Calculate the maximum number of grouping sets in any phase; this
+	 * determines the size of some allocations.  Also calculate the number of
+	 * phases, since all hashed/mixed nodes contribute to only a single phase.
+	 */
+	if (node->groupingSets)
+	{
+		numGroupingSets = list_length(node->groupingSets);
+
+		foreach(l, node->chain)
+		{
+			Agg		   *agg = lfirst(l);
+
+			numGroupingSets = Max(numGroupingSets,
+								  list_length(agg->groupingSets));
+
+			/*
+			 * additional AGG_HASHED aggs become part of phase 0, but all
+			 * others add an extra phase.
+			 */
+			if (agg->aggstrategy != AGG_HASHED)
+				++numPhases;
+			else
+				++numHashes;
+		}
+	}
+
+	aggstate->maxsets = numGroupingSets;
+	aggstate->numphases = numPhases;
+
+	aggstate->aggcontexts = (ExprContext **)
+		palloc0(sizeof(ExprContext *) * numGroupingSets);
+
+	/*
+	 * Create expression contexts.  We need three or more, one for
+	 * per-input-tuple processing, one for per-output-tuple processing, one
+	 * for all the hashtables, and one for each grouping set.  The per-tuple
+	 * memory context of the per-grouping-set ExprContexts (aggcontexts)
+	 * replaces the standalone memory context formerly used to hold transition
+	 * values.  We cheat a little by using ExecAssignExprContext() to build
+	 * all of them.
+	 *
+	 * NOTE: the details of what is stored in aggcontexts and what is stored
+	 * in the regular per-query memory context are driven by a simple
+	 * decision: we want to reset the aggcontext at group boundaries (if not
+	 * hashing) and in ExecReScanAgg to recover no-longer-wanted space.
+	 */
+	ExecAssignExprContext(estate, &aggstate->ss.ps);
+	aggstate->tmpcontext = aggstate->ss.ps.ps_ExprContext;
+
+	for (i = 0; i < numGroupingSets; ++i)
+	{
+		ExecAssignExprContext(estate, &aggstate->ss.ps);
+		aggstate->aggcontexts[i] = aggstate->ss.ps.ps_ExprContext;
+	}
+
+	if (use_hashing)
+		aggstate->hashcontext = CreateWorkExprContext(estate);
+
+	ExecAssignExprContext(estate, &aggstate->ss.ps);
+
+	/*
+	 * Initialize child nodes.
+	 *
+	 * If we are doing a hashed aggregation then the child plan does not need
+	 * to handle REWIND efficiently; see ExecReScanAgg.
+	 */
+	if (node->aggstrategy == AGG_HASHED)
+		eflags &= ~EXEC_FLAG_REWIND;
+	outerPlan = outerPlan(node);
+	outerPlanState(aggstate) = ExecInitNode(outerPlan, estate, eflags);
+
+	/*
+	 * initialize source tuple type.
+	 */
+	aggstate->ss.ps.outerops =
+		ExecGetResultSlotOps(outerPlanState(&aggstate->ss),
+							 &aggstate->ss.ps.outeropsfixed);
+	aggstate->ss.ps.outeropsset = true;
+
+	ExecCreateScanSlotFromOuterPlan(estate, &aggstate->ss,
+									aggstate->ss.ps.outerops);
+	scanDesc = aggstate->ss.ss_ScanTupleSlot->tts_tupleDescriptor;
+
+	/*
+	 * If there are more than two phases (including a potential dummy phase
+	 * 0), input will be resorted using tuplesort. Need a slot for that.
+	 */
+	if (numPhases > 2)
+	{
+		aggstate->sort_slot = ExecInitExtraTupleSlot(estate, scanDesc,
+													 &TTSOpsMinimalTuple);
+
+		/*
+		 * The output of the tuplesort, and the output from the outer child
+		 * might not use the same type of slot. In most cases the child will
+		 * be a Sort, and thus return a TTSOpsMinimalTuple type slot - but the
+		 * input can also be presorted due an index, in which case it could be
+		 * a different type of slot.
+		 *
+		 * XXX: For efficiency it would be good to instead/additionally
+		 * generate expressions with corresponding settings of outerops* for
+		 * the individual phases - deforming is often a bottleneck for
+		 * aggregations with lots of rows per group. If there's multiple
+		 * sorts, we know that all but the first use TTSOpsMinimalTuple (via
+		 * the nodeAgg.c internal tuplesort).
+		 */
+		if (aggstate->ss.ps.outeropsfixed &&
+			aggstate->ss.ps.outerops != &TTSOpsMinimalTuple)
+			aggstate->ss.ps.outeropsfixed = false;
+	}
+
+	/*
+	 * Initialize result type, slot and projection.
+	 */
+	ExecInitResultTupleSlotTL(&aggstate->ss.ps, &TTSOpsVirtual);
+	ExecAssignProjectionInfo(&aggstate->ss.ps, NULL);
+
+	/*
+	 * initialize child expressions
+	 *
+	 * We expect the parser to have checked that no aggs contain other agg
+	 * calls in their arguments (and just to be sure, we verify it again while
+	 * initializing the plan node).  This would make no sense under SQL
+	 * semantics, and it's forbidden by the spec.  Because it is true, we
+	 * don't need to worry about evaluating the aggs in any particular order.
+	 *
+	 * Note: execExpr.c finds Aggrefs for us, and adds them to aggstate->aggs.
+	 * Aggrefs in the qual are found here; Aggrefs in the targetlist are found
+	 * during ExecAssignProjectionInfo, above.
+	 */
+	aggstate->ss.ps.qual =
+		ExecInitQual(node->plan.qual, (PlanState *) aggstate);
+
+	/*
+	 * We should now have found all Aggrefs in the targetlist and quals.
+	 */
+	numaggrefs = list_length(aggstate->aggs);
+	max_aggno = -1;
+	max_transno = -1;
+	foreach(l, aggstate->aggs)
+	{
+		Aggref	   *aggref = (Aggref *) lfirst(l);
+
+		max_aggno = Max(max_aggno, aggref->aggno);
+		max_transno = Max(max_transno, aggref->aggtransno);
+	}
+	numaggs = max_aggno + 1;
+	numtrans = max_transno + 1;
+
+	/*
+	 * For each phase, prepare grouping set data and fmgr lookup data for
+	 * compare functions.  Accumulate all_grouped_cols in passing.
+	 */
+	aggstate->phases = palloc0(numPhases * sizeof(AggStatePerPhaseData));
+
+	aggstate->num_hashes = numHashes;
+	if (numHashes)
+	{
+		aggstate->perhash = palloc0(sizeof(AggStatePerHashData) * numHashes);
+		aggstate->phases[0].numsets = 0;
+		aggstate->phases[0].gset_lengths = palloc(numHashes * sizeof(int));
+		aggstate->phases[0].grouped_cols = palloc(numHashes * sizeof(Bitmapset *));
+	}
+
+	phase = 0;
+	for (phaseidx = 0; phaseidx <= list_length(node->chain); ++phaseidx)
+	{
+		Agg		   *aggnode;
+		Sort	   *sortnode;
+
+		if (phaseidx > 0)
+		{
+			aggnode = list_nth_node(Agg, node->chain, phaseidx - 1);
+			sortnode = castNode(Sort, aggnode->plan.lefttree);
+		}
+		else
+		{
+			aggnode = node;
+			sortnode = NULL;
+		}
+
+		Assert(phase <= 1 || sortnode);
+
+		if (aggnode->aggstrategy == AGG_HASHED
+			|| aggnode->aggstrategy == AGG_MIXED)
+		{
+			AggStatePerPhase phasedata = &aggstate->phases[0];
+			AggStatePerHash perhash;
+			Bitmapset  *cols = NULL;
+
+			Assert(phase == 0);
+			i = phasedata->numsets++;
+			perhash = &aggstate->perhash[i];
+
+			/* phase 0 always points to the "real" Agg in the hash case */
+			phasedata->aggnode = node;
+			phasedata->aggstrategy = node->aggstrategy;
+
+			/* but the actual Agg node representing this hash is saved here */
+			perhash->aggnode = aggnode;
+
+			phasedata->gset_lengths[i] = perhash->numCols = aggnode->numCols;
+
+			for (j = 0; j < aggnode->numCols; ++j)
+				cols = bms_add_member(cols, aggnode->grpColIdx[j]);
+
+			phasedata->grouped_cols[i] = cols;
+
+			all_grouped_cols = bms_add_members(all_grouped_cols, cols);
+			continue;
+		}
+		else
+		{
+			AggStatePerPhase phasedata = &aggstate->phases[++phase];
+			int			num_sets;
+
+			phasedata->numsets = num_sets = list_length(aggnode->groupingSets);
+
+			if (num_sets)
+			{
+				phasedata->gset_lengths = palloc(num_sets * sizeof(int));
+				phasedata->grouped_cols = palloc(num_sets * sizeof(Bitmapset *));
+
+				i = 0;
+				foreach(l, aggnode->groupingSets)
+				{
+					int			current_length = list_length(lfirst(l));
+					Bitmapset  *cols = NULL;
+
+					/* planner forces this to be correct */
+					for (j = 0; j < current_length; ++j)
+						cols = bms_add_member(cols, aggnode->grpColIdx[j]);
+
+					phasedata->grouped_cols[i] = cols;
+					phasedata->gset_lengths[i] = current_length;
+
+					++i;
+				}
+
+				all_grouped_cols = bms_add_members(all_grouped_cols,
+												   phasedata->grouped_cols[0]);
+			}
+			else
+			{
+				Assert(phaseidx == 0);
+
+				phasedata->gset_lengths = NULL;
+				phasedata->grouped_cols = NULL;
+			}
+
+			/*
+			 * If we are grouping, precompute fmgr lookup data for inner loop.
+			 */
+			if (aggnode->aggstrategy == AGG_SORTED)
+			{
+				i = 0;
+
+				Assert(aggnode->numCols > 0);
+
+				/*
+				 * Build a separate function for each subset of columns that
+				 * need to be compared.
+				 */
+				phasedata->eqfunctions =
+					(ExprState **) palloc0(aggnode->numCols * sizeof(ExprState *));
+
+				/* for each grouping set */
+				for (i = 0; i < phasedata->numsets; i++)
+				{
+					int			length = phasedata->gset_lengths[i];
+
+					/* nothing to do for empty grouping set */
+					if (length == 0)
+						continue;
+
+					/* if we already had one of this length, it'll do */
+					if (phasedata->eqfunctions[length - 1] != NULL)
+						continue;
+
+					phasedata->eqfunctions[length - 1] =
+						execTuplesMatchPrepare(scanDesc,
+											   length,
+											   aggnode->grpColIdx,
+											   aggnode->grpOperators,
+											   aggnode->grpCollations,
+											   (PlanState *) aggstate);
+				}
+
+				/* and for all grouped columns, unless already computed */
+				if (phasedata->eqfunctions[aggnode->numCols - 1] == NULL)
+				{
+					phasedata->eqfunctions[aggnode->numCols - 1] =
+						execTuplesMatchPrepare(scanDesc,
+											   aggnode->numCols,
+											   aggnode->grpColIdx,
+											   aggnode->grpOperators,
+											   aggnode->grpCollations,
+											   (PlanState *) aggstate);
+				}
+			}
+
+			phasedata->aggnode = aggnode;
+			phasedata->aggstrategy = aggnode->aggstrategy;
+			phasedata->sortnode = sortnode;
+		}
+	}
+
+	/*
+	 * Convert all_grouped_cols to a descending-order list.
+	 */
+	i = -1;
+	while ((i = bms_next_member(all_grouped_cols, i)) >= 0)
+		aggstate->all_grouped_cols = lcons_int(i, aggstate->all_grouped_cols);
+
+	/*
+	 * Set up aggregate-result storage in the output expr context, and also
+	 * allocate my private per-agg working storage
+	 */
+	econtext = aggstate->ss.ps.ps_ExprContext;
+	econtext->ecxt_aggvalues = (Datum *) palloc0(sizeof(Datum) * numaggs);
+	econtext->ecxt_aggnulls = (bool *) palloc0(sizeof(bool) * numaggs);
+
+	peraggs = (AggStatePerAgg) palloc0(sizeof(AggStatePerAggData) * numaggs);
+	pertransstates = (AggStatePerTrans) palloc0(sizeof(AggStatePerTransData) * numtrans);
+
+	aggstate->peragg = peraggs;
+	aggstate->pertrans = pertransstates;
+
+
+	aggstate->all_pergroups =
+		(AggStatePerGroup *) palloc0(sizeof(AggStatePerGroup)
+									 * (numGroupingSets + numHashes));
+	pergroups = aggstate->all_pergroups;
+
+	if (node->aggstrategy != AGG_HASHED)
+	{
+		for (i = 0; i < numGroupingSets; i++)
+		{
+			pergroups[i] = (AggStatePerGroup) palloc0(sizeof(AggStatePerGroupData)
+													  * numaggs);
+		}
+
+		aggstate->pergroups = pergroups;
+		pergroups += numGroupingSets;
+	}
+
+	/*
+	 * Hashing can only appear in the initial phase.
+	 */
+	if (use_hashing)
+	{
+		Plan	   *outerplan = outerPlan(node);
+		uint64		totalGroups = 0;
+
+		aggstate->hash_metacxt = AllocSetContextCreate(aggstate->ss.ps.state->es_query_cxt,
+													   "HashAgg meta context",
+													   ALLOCSET_DEFAULT_SIZES);
+		aggstate->hash_spill_rslot = ExecInitExtraTupleSlot(estate, scanDesc,
+															&TTSOpsMinimalTuple);
+		aggstate->hash_spill_wslot = ExecInitExtraTupleSlot(estate, scanDesc,
+															&TTSOpsVirtual);
+
+		/* this is an array of pointers, not structures */
+		aggstate->hash_pergroup = pergroups;
+
+		aggstate->hashentrysize = hash_agg_entry_size(aggstate->numtrans,
+													  outerplan->plan_width,
+													  node->transitionSpace);
+
+		/*
+		 * Consider all of the grouping sets together when setting the limits
+		 * and estimating the number of partitions. This can be inaccurate
+		 * when there is more than one grouping set, but should still be
+		 * reasonable.
+		 */
+		for (i = 0; i < aggstate->num_hashes; i++)
+			totalGroups += aggstate->perhash[i].aggnode->numGroups;
+
+		hash_agg_set_limits(aggstate->hashentrysize, totalGroups, 0,
+							&aggstate->hash_mem_limit,
+							&aggstate->hash_ngroups_limit,
+							&aggstate->hash_planned_partitions);
+		find_hash_columns(aggstate);
+
+		/* Skip massive memory allocation if we are just doing EXPLAIN */
+		if (!(eflags & EXEC_FLAG_EXPLAIN_ONLY))
+			build_hash_tables(aggstate);
+
+		aggstate->table_filled = false;
+
+		/* Initialize this to 1, meaning nothing spilled, yet */
+		aggstate->hash_batches_used = 1;
+	}
+
+	/*
+	 * Initialize current phase-dependent values to initial phase. The initial
+	 * phase is 1 (first sort pass) for all strategies that use sorting (if
+	 * hashing is being done too, then phase 0 is processed last); but if only
+	 * hashing is being done, then phase 0 is all there is.
+	 */
+	if (node->aggstrategy == AGG_HASHED)
+	{
+		aggstate->current_phase = 0;
+		initialize_phase(aggstate, 0);
+		select_current_set(aggstate, 0, true);
+	}
+	else
+	{
+		aggstate->current_phase = 1;
+		initialize_phase(aggstate, 1);
+		select_current_set(aggstate, 0, false);
+	}
+
+	/*
+	 * Perform lookups of aggregate function info, and initialize the
+	 * unchanging fields of the per-agg and per-trans data.
+	 */
+	foreach(l, aggstate->aggs)
+	{
+		Aggref	   *aggref = lfirst(l);
+		AggStatePerAgg peragg;
+		AggStatePerTrans pertrans;
+#if PG_VERSION_NUM < PG_VERSION_15
+		Oid			inputTypes[FUNC_MAX_ARGS];
+		int			numArguments;
+#else
+		Oid			aggTransFnInputTypes[FUNC_MAX_ARGS];
+		int			numAggTransFnArgs;
+#endif
+		int			numDirectArgs;
+		HeapTuple	aggTuple;
+		Form_pg_aggregate aggform;
+		AclResult	aclresult;
+		Oid			finalfn_oid;
+		Oid			serialfn_oid,
+					deserialfn_oid;
+		Oid			aggOwner;
+		Expr	   *finalfnexpr;
+		Oid			aggtranstype;
+
+		/* Planner should have assigned aggregate to correct level */
+		Assert(aggref->agglevelsup == 0);
+		/* ... and the split mode should match */
+		Assert(aggref->aggsplit == aggstate->aggsplit);
+
+		peragg = &peraggs[aggref->aggno];
+
+		/* Check if we initialized the state for this aggregate already. */
+		if (peragg->aggref != NULL)
+			continue;
+
+		peragg->aggref = aggref;
+		peragg->transno = aggref->aggtransno;
+
+		/* Fetch the pg_aggregate row */
+		aggTuple = SearchSysCache1(AGGFNOID,
+								   ObjectIdGetDatum(aggref->aggfnoid));
+		if (!HeapTupleIsValid(aggTuple))
+			elog(ERROR, "cache lookup failed for aggregate %u",
+				 aggref->aggfnoid);
+		aggform = (Form_pg_aggregate) GETSTRUCT(aggTuple);
+
+		/* Check permission to call aggregate function */
+		aclresult = pg_proc_aclcheck(aggref->aggfnoid, GetUserId(),
+									 ACL_EXECUTE);
+		if (aclresult != ACLCHECK_OK)
+			aclcheck_error(aclresult, OBJECT_AGGREGATE,
+						   get_func_name(aggref->aggfnoid));
+		InvokeFunctionExecuteHook(aggref->aggfnoid);
+
+		/* planner recorded transition state type in the Aggref itself */
+		aggtranstype = aggref->aggtranstype;
+		Assert(OidIsValid(aggtranstype));
+
+		/* Final function only required if we're finalizing the aggregates */
+		if (DO_AGGSPLIT_SKIPFINAL(aggstate->aggsplit))
+			peragg->finalfn_oid = finalfn_oid = InvalidOid;
+		else
+			peragg->finalfn_oid = finalfn_oid = aggform->aggfinalfn;
+
+		serialfn_oid = InvalidOid;
+		deserialfn_oid = InvalidOid;
+
+		/*
+		 * Check if serialization/deserialization is required.  We only do it
+		 * for aggregates that have transtype INTERNAL.
+		 */
+		if (aggtranstype == INTERNALOID)
+		{
+			/*
+			 * The planner should only have generated a serialize agg node if
+			 * every aggregate with an INTERNAL state has a serialization
+			 * function.  Verify that.
+			 */
+			if (DO_AGGSPLIT_SERIALIZE(aggstate->aggsplit))
+			{
+				/* serialization only valid when not running finalfn */
+				Assert(DO_AGGSPLIT_SKIPFINAL(aggstate->aggsplit));
+
+				if (!OidIsValid(aggform->aggserialfn))
+					elog(ERROR, "serialfunc not provided for serialization aggregation");
+				serialfn_oid = aggform->aggserialfn;
+			}
+
+			/* Likewise for deserialization functions */
+			if (DO_AGGSPLIT_DESERIALIZE(aggstate->aggsplit))
+			{
+				/* deserialization only valid when combining states */
+				Assert(DO_AGGSPLIT_COMBINE(aggstate->aggsplit));
+
+				if (!OidIsValid(aggform->aggdeserialfn))
+					elog(ERROR, "deserialfunc not provided for deserialization aggregation");
+				deserialfn_oid = aggform->aggdeserialfn;
+			}
+		}
+
+		/* Check that aggregate owner has permission to call component fns */
+		{
+			HeapTuple	procTuple;
+
+			procTuple = SearchSysCache1(PROCOID,
+										ObjectIdGetDatum(aggref->aggfnoid));
+			if (!HeapTupleIsValid(procTuple))
+				elog(ERROR, "cache lookup failed for function %u",
+					 aggref->aggfnoid);
+			aggOwner = ((Form_pg_proc) GETSTRUCT(procTuple))->proowner;
+			ReleaseSysCache(procTuple);
+
+			if (OidIsValid(finalfn_oid))
+			{
+				aclresult = pg_proc_aclcheck(finalfn_oid, aggOwner,
+											 ACL_EXECUTE);
+				if (aclresult != ACLCHECK_OK)
+					aclcheck_error(aclresult, OBJECT_FUNCTION,
+								   get_func_name(finalfn_oid));
+				InvokeFunctionExecuteHook(finalfn_oid);
+			}
+			if (OidIsValid(serialfn_oid))
+			{
+				aclresult = pg_proc_aclcheck(serialfn_oid, aggOwner,
+											 ACL_EXECUTE);
+				if (aclresult != ACLCHECK_OK)
+					aclcheck_error(aclresult, OBJECT_FUNCTION,
+								   get_func_name(serialfn_oid));
+				InvokeFunctionExecuteHook(serialfn_oid);
+			}
+			if (OidIsValid(deserialfn_oid))
+			{
+				aclresult = pg_proc_aclcheck(deserialfn_oid, aggOwner,
+											 ACL_EXECUTE);
+				if (aclresult != ACLCHECK_OK)
+					aclcheck_error(aclresult, OBJECT_FUNCTION,
+								   get_func_name(deserialfn_oid));
+				InvokeFunctionExecuteHook(deserialfn_oid);
+			}
+		}
+
+		/*
+		 * Get actual datatypes of the (nominal) aggregate inputs.  These
+		 * could be different from the agg's declared input types, when the
+		 * agg accepts ANY or a polymorphic type.
+		 */
+#if PG_VERSION_NUM < PG_VERSION_15
+		numArguments = get_aggregate_argtypes(aggref, inputTypes);
+#else
+		numAggTransFnArgs = get_aggregate_argtypes(aggref,
+												   aggTransFnInputTypes);
+#endif
+
+		/* Count the "direct" arguments, if any */
+		numDirectArgs = list_length(aggref->aggdirectargs);
+
+		/* Detect how many arguments to pass to the finalfn */
+		if (aggform->aggfinalextra)
+#if PG_VERSION_NUM < PG_VERSION_15
+			peragg->numFinalArgs = numArguments + 1;
+#else
+			peragg->numFinalArgs = numAggTransFnArgs + 1;
+#endif
+		else
+			peragg->numFinalArgs = numDirectArgs + 1;
+
+		/* Initialize any direct-argument expressions */
+		peragg->aggdirectargs = ExecInitExprList(aggref->aggdirectargs,
+												 (PlanState *) aggstate);
+
+		/*
+		 * build expression trees using actual argument & result types for the
+		 * finalfn, if it exists and is required.
+		 */
+		if (OidIsValid(finalfn_oid))
+		{
+#if PG_VERSION_NUM < PG_VERSION_15
+			build_aggregate_finalfn_expr(inputTypes,
+#else
+			build_aggregate_finalfn_expr(aggTransFnInputTypes,
+#endif
+										 peragg->numFinalArgs,
+										 aggtranstype,
+										 aggref->aggtype,
+										 aggref->inputcollid,
+										 finalfn_oid,
+										 &finalfnexpr);
+			fmgr_info(finalfn_oid, &peragg->finalfn);
+			fmgr_info_set_expr((Node *) finalfnexpr, &peragg->finalfn);
+		}
+
+		/* get info about the output value's datatype */
+		get_typlenbyval(aggref->aggtype,
+						&peragg->resulttypeLen,
+						&peragg->resulttypeByVal);
+
+		/*
+		 * Build working state for invoking the transition function, if we
+		 * haven't done it already.
+		 */
+		pertrans = &pertransstates[aggref->aggtransno];
+		if (pertrans->aggref == NULL)
+		{
+			Datum		textInitVal;
+			Datum		initValue;
+			bool		initValueIsNull;
+			Oid			transfn_oid;
+
+			/*
+			 * If this aggregation is performing state combines, then instead
+			 * of using the transition function, we'll use the combine function.
+			 */
+			if (DO_AGGSPLIT_COMBINE(aggstate->aggsplit))
+			{
+				transfn_oid = aggform->aggcombinefn;
+
+				/* If not set then the planner messed up */
+				if (!OidIsValid(transfn_oid))
+					elog(ERROR, "combinefn not set for aggregate function");
+			}
+			else
+				transfn_oid = aggform->aggtransfn;
+
+#if PG_VERSION_NUM < PG_VERSION_15
+			aclresult = pg_proc_aclcheck(transfn_oid, aggOwner,
+										 ACL_EXECUTE);
+#else
+			aclresult = pg_proc_aclcheck(transfn_oid, aggOwner, ACL_EXECUTE);
+#endif
+			if (aclresult != ACLCHECK_OK)
+				aclcheck_error(aclresult, OBJECT_FUNCTION,
+							   get_func_name(transfn_oid));
+			InvokeFunctionExecuteHook(transfn_oid);
+
+			/*
+			 * initval is potentially null, so don't try to access it as a
+			 * struct field. Must do it the hard way with SysCacheGetAttr.
+			 */
+			textInitVal = SysCacheGetAttr(AGGFNOID, aggTuple,
+										  Anum_pg_aggregate_agginitval,
+										  &initValueIsNull);
+			if (initValueIsNull)
+				initValue = (Datum) 0;
+			else
+				initValue = GetAggInitVal(textInitVal, aggtranstype);
+
+#if PG_VERSION_NUM < PG_VERSION_15
+			build_pertrans_for_aggref(pertrans, aggstate, estate,
+									  aggref, transfn_oid, aggtranstype,
+									  serialfn_oid, deserialfn_oid,
+									  initValue, initValueIsNull,
+									  inputTypes, numArguments);
+#else
+			if (DO_AGGSPLIT_COMBINE(aggstate->aggsplit))
+			{
+				Oid			combineFnInputTypes[] = {aggtranstype,
+				aggtranstype};
+
+				/*
+				 * When combining there's only one input, the to-be-combined
+				 * transition value.  The transition value is not counted
+				 * here.
+				 */
+				pertrans->numTransInputs = 1;
+
+				/* aggcombinefn always has two arguments of aggtranstype */
+				build_pertrans_for_aggref(pertrans, aggstate, estate,
+										  aggref, transfn_oid, aggtranstype,
+										  serialfn_oid, deserialfn_oid,
+										  initValue, initValueIsNull,
+										  combineFnInputTypes, 2);
+
+				/*
+				 * Ensure that a combine function to combine INTERNAL states
+				 * is not strict. This should have been checked during CREATE
+				 * AGGREGATE, but the strict property could have been changed
+				 * since then.
+				 */
+				if (pertrans->transfn.fn_strict && aggtranstype == INTERNALOID)
+					ereport(ERROR,
+							(errcode(ERRCODE_INVALID_FUNCTION_DEFINITION),
+							 errmsg("combine function with transition type %s must not be declared STRICT",
+									format_type_be(aggtranstype))));
+			}
+			else
+			{
+				/* Detect how many arguments to pass to the transfn */
+				if (AGGKIND_IS_ORDERED_SET(aggref->aggkind))
+					pertrans->numTransInputs = list_length(aggref->args);
+				else
+					pertrans->numTransInputs = numAggTransFnArgs;
+
+				build_pertrans_for_aggref(pertrans, aggstate, estate,
+										  aggref, transfn_oid, aggtranstype,
+										  serialfn_oid, deserialfn_oid,
+										  initValue, initValueIsNull,
+										  aggTransFnInputTypes,
+										  numAggTransFnArgs);
+
+				/*
+				 * If the transfn is strict and the initval is NULL, make sure
+				 * input type and transtype are the same (or at least
+				 * binary-compatible), so that it's OK to use the first
+				 * aggregated input value as the initial transValue.  This
+				 * should have been checked at agg definition time, but we
+				 * must check again in case the transfn's strictness property
+				 * has been changed.
+				 */
+				if (pertrans->transfn.fn_strict && pertrans->initValueIsNull)
+				{
+					if (numAggTransFnArgs <= numDirectArgs ||
+						!IsBinaryCoercible(aggTransFnInputTypes[numDirectArgs],
+										   aggtranstype))
+						ereport(ERROR,
+								(errcode(ERRCODE_INVALID_FUNCTION_DEFINITION),
+								 errmsg("aggregate %u needs to have compatible input type and transition type",
+										aggref->aggfnoid)));
+				}
+			}
+#endif /* PG_VERSION_NUM >= PG_VERSION_15 */
+		}
+		else
+			pertrans->aggshared = true;
+		ReleaseSysCache(aggTuple);
+	}
+
+	/*
+	 * Update aggstate->numaggs to be the number of unique aggregates found.
+	 * Also set numstates to the number of unique transition states found.
+	 */
+	aggstate->numaggs = numaggs;
+	aggstate->numtrans = numtrans;
+
+	/*
+	 * Last, check whether any more aggregates got added onto the node while
+	 * we processed the expressions for the aggregate arguments (including not
+	 * only the regular arguments and FILTER expressions handled immediately
+	 * above, but any direct arguments we might've handled earlier).  If so,
+	 * we have nested aggregate functions, which is semantically nonsensical,
+	 * so complain.  (This should have been caught by the parser, so we don't
+	 * need to work hard on a helpful error message; but we defend against it
+	 * here anyway, just to be sure.)
+	 */
+	if (numaggrefs != list_length(aggstate->aggs))
+		ereport(ERROR,
+				(errcode(ERRCODE_GROUPING_ERROR),
+				 errmsg("aggregate function calls cannot be nested")));
+
+	/*
+	 * Build expressions doing all the transition work at once. We build a
+	 * different one for each phase, as the number of transition function
+	 * invocation can differ between phases. Note this'll work both for
+	 * transition and combination functions (although there'll only be one
+	 * phase in the latter case).
+	 */
+	for (phaseidx = 0; phaseidx < aggstate->numphases; phaseidx++)
+	{
+		AggStatePerPhase statePerPhase = &aggstate->phases[phaseidx];
+		bool		dohash = false;
+		bool		dosort = false;
+
+		/* phase 0 doesn't necessarily exist */
+		if (!statePerPhase->aggnode)
+			continue;
+
+		if (aggstate->aggstrategy == AGG_MIXED && phaseidx == 1)
+		{
+			/*
+			 * Phase one, and only phase one, in a mixed agg performs both
+			 * sorting and aggregation.
+			 */
+			dohash = true;
+			dosort = true;
+		}
+		else if (aggstate->aggstrategy == AGG_MIXED && phaseidx == 0)
+		{
+			/*
+			 * No need to compute a transition function for an AGG_MIXED phase
+			 * 0 - the contents of the hashtables will have been computed
+			 * during phase 1.
+			 */
+			continue;
+		}
+		else if (statePerPhase->aggstrategy == AGG_PLAIN ||
+				 statePerPhase->aggstrategy == AGG_SORTED)
+		{
+			dohash = false;
+			dosort = true;
+		}
+		else if (statePerPhase->aggstrategy == AGG_HASHED)
+		{
+			dohash = true;
+			dosort = false;
+		}
+		else
+			Assert(false);
+
+		statePerPhase->evaltrans = ExecBuildAggTrans(aggstate, statePerPhase, dosort, dohash,
+													 false);
+
+		/* cache compiled expression for outer slot without NULL check */
+		statePerPhase->evaltrans_cache[0][0] = statePerPhase->evaltrans;
+	}
+
+	return aggstate;
+}
+
+/*
+ * Build the state needed to calculate a state value for an aggregate.
+ *
+ * This initializes all the fields in 'pertrans'. 'aggref' is the aggregate
+#if PG_VERSION_NUM < PG_VERSION_15
+ * to initialize the state for. 'aggtransfn', 'aggtranstype', and the rest
+#else
+ * to initialize the state for. 'transfn_oid', 'aggtranstype', and the rest
+#endif
+ * of the arguments could be calculated from 'aggref', but the caller has
+ * calculated them already, so might as well pass them.
+#if PG_VERSION_NUM >= PG_VERSION_15
+ *
+ * 'transfn_oid' may be either the Oid of the aggtransfn or the aggcombinefn.
+#endif
+ */
+static void
+build_pertrans_for_aggref(AggStatePerTrans pertrans,
+						  AggState *aggstate, EState *estate,
+						  Aggref *aggref,
+#if PG_VERSION_NUM < PG_VERSION_15
+						  Oid aggtransfn, Oid aggtranstype,
+#else
+						  Oid transfn_oid, Oid aggtranstype,
+#endif
+						  Oid aggserialfn, Oid aggdeserialfn,
+						  Datum initValue, bool initValueIsNull,
+						  Oid *inputTypes, int numArguments)
+{
+	int			numGroupingSets = Max(aggstate->maxsets, 1);
+#if PG_VERSION_NUM >= PG_VERSION_15
+	Expr	   *transfnexpr;
+	int			numTransArgs;
+#endif
+	Expr	   *serialfnexpr = NULL;
+	Expr	   *deserialfnexpr = NULL;
+	ListCell   *lc;
+	int			numInputs;
+	int			numDirectArgs;
+	List	   *sortlist;
+	int			numSortCols;
+	int			numDistinctCols;
+	int			i;
+
+	/* Begin filling in the pertrans data */
+	pertrans->aggref = aggref;
+	pertrans->aggshared = false;
+	pertrans->aggCollation = aggref->inputcollid;
+#if PG_VERSION_NUM < PG_VERSION_15
+	pertrans->transfn_oid = aggtransfn;
+#else
+	pertrans->transfn_oid = transfn_oid;
+#endif
+	pertrans->serialfn_oid = aggserialfn;
+	pertrans->deserialfn_oid = aggdeserialfn;
+	pertrans->initValue = initValue;
+	pertrans->initValueIsNull = initValueIsNull;
+
+	/* Count the "direct" arguments, if any */
+	numDirectArgs = list_length(aggref->aggdirectargs);
+
+	/* Count the number of aggregated input columns */
+	pertrans->numInputs = numInputs = list_length(aggref->args);
+
+	pertrans->aggtranstype = aggtranstype;
+
+#if PG_VERSION_NUM >= PG_VERSION_15
+	/* account for the current transition state */
+	numTransArgs = pertrans->numTransInputs + 1;
+#endif
+
+	/*
+#if PG_VERSION_NUM < PG_VERSION_15
+	 * When combining states, we have no use at all for the aggregate
+	 * function's transfn. Instead we use the combinefn.  In this case, the
+	 * transfn and transfn_oid fields of pertrans refer to the combine
+	 * function rather than the transition function.
+#else
+	 * Set up infrastructure for calling the transfn.  Note that invtrans is
+	 * not needed here.
+#endif
+	 */
+
+#if PG_VERSION_NUM < PG_VERSION_15
+	if (DO_AGGSPLIT_COMBINE(aggstate->aggsplit))
+	{
+		Expr	   *combinefnexpr;
+		size_t		numTransArgs;
+
+		/*
+		 * When combining there's only one input, the to-be-combined added
+		 * transition value from below (this node's transition value is
+		 * counted separately).
+		 */
+		pertrans->numTransInputs = 1;
+
+		/* account for the current transition state */
+		numTransArgs = pertrans->numTransInputs + 1;
+
+		build_aggregate_combinefn_expr(aggtranstype,
+									   aggref->inputcollid,
+									   aggtransfn,
+									   &combinefnexpr);
+		fmgr_info(aggtransfn, &pertrans->transfn);
+		fmgr_info_set_expr((Node *) combinefnexpr, &pertrans->transfn);
+
+		pertrans->transfn_fcinfo =
+			(FunctionCallInfo) palloc(SizeForFunctionCallInfo(2));
+		InitFunctionCallInfoData(*pertrans->transfn_fcinfo,
+								 &pertrans->transfn,
+								 numTransArgs,
+								 pertrans->aggCollation,
+								 (void *) aggstate, NULL);
+
+		/*
+		 * Ensure that a combine function to combine INTERNAL states is not
+		 * strict. This should have been checked during CREATE AGGREGATE, but
+		 * the strict property could have been changed since then.
+		 */
+		if (pertrans->transfn.fn_strict && aggtranstype == INTERNALOID)
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_FUNCTION_DEFINITION),
+					 errmsg("combine function with transition type %s must not be declared STRICT",
+							format_type_be(aggtranstype))));
+	}
+	else
+	{
+		Expr	   *transfnexpr;
+		size_t		numTransArgs;
+
+		/* Detect how many arguments to pass to the transfn */
+		if (AGGKIND_IS_ORDERED_SET(aggref->aggkind))
+			pertrans->numTransInputs = numInputs;
+		else
+			pertrans->numTransInputs = numArguments;
+
+		/* account for the current transition state */
+		numTransArgs = pertrans->numTransInputs + 1;
+#else
+	build_aggregate_transfn_expr(inputTypes,
+								 numArguments,
+								 numDirectArgs,
+								 aggref->aggvariadic,
+								 aggtranstype,
+								 aggref->inputcollid,
+								 transfn_oid,
+								 InvalidOid,
+								 &transfnexpr,
+								 NULL);
+#endif
+
+#if PG_VERSION_NUM < PG_VERSION_15
+		/*
+		 * Set up infrastructure for calling the transfn.  Note that
+		 * invtransfn is not needed here.
+		 */
+		build_aggregate_transfn_expr(inputTypes,
+									 numArguments,
+									 numDirectArgs,
+									 aggref->aggvariadic,
+									 aggtranstype,
+									 aggref->inputcollid,
+									 aggtransfn,
+									 InvalidOid,
+									 &transfnexpr,
+									 NULL);
+		fmgr_info(aggtransfn, &pertrans->transfn);
+		fmgr_info_set_expr((Node *) transfnexpr, &pertrans->transfn);
+
+		pertrans->transfn_fcinfo =
+			(FunctionCallInfo) palloc(SizeForFunctionCallInfo(numTransArgs));
+		InitFunctionCallInfoData(*pertrans->transfn_fcinfo,
+								 &pertrans->transfn,
+								 numTransArgs,
+								 pertrans->aggCollation,
+								 (void *) aggstate, NULL);
+#else
+	fmgr_info(transfn_oid, &pertrans->transfn);
+	fmgr_info_set_expr((Node *) transfnexpr, &pertrans->transfn);
+#endif
+
+#if PG_VERSION_NUM < PG_VERSION_15
+		/*
+		 * If the transfn is strict and the initval is NULL, make sure input
+		 * type and transtype are the same (or at least binary-compatible), so
+		 * that it's OK to use the first aggregated input value as the initial
+		 * transValue.  This should have been checked at agg definition time,
+		 * but we must check again in case the transfn's strictness property
+		 * has been changed.
+		 */
+		if (pertrans->transfn.fn_strict && pertrans->initValueIsNull)
+		{
+			if (numArguments <= numDirectArgs ||
+				!IsBinaryCoercible(inputTypes[numDirectArgs],
+								   aggtranstype))
+				ereport(ERROR,
+						(errcode(ERRCODE_INVALID_FUNCTION_DEFINITION),
+						 errmsg("aggregate %u needs to have compatible input type and transition type",
+								aggref->aggfnoid)));
+		}
+	}
+#else
+	pertrans->transfn_fcinfo =
+		(FunctionCallInfo) palloc(SizeForFunctionCallInfo(numTransArgs));
+	InitFunctionCallInfoData(*pertrans->transfn_fcinfo,
+							 &pertrans->transfn,
+							 numTransArgs,
+							 pertrans->aggCollation,
+							 (void *) aggstate, NULL);
+#endif
+
+	/* get info about the state value's datatype */
+	get_typlenbyval(aggtranstype,
+					&pertrans->transtypeLen,
+					&pertrans->transtypeByVal);
+
+	if (OidIsValid(aggserialfn))
+	{
+		build_aggregate_serialfn_expr(aggserialfn,
+									  &serialfnexpr);
+		fmgr_info(aggserialfn, &pertrans->serialfn);
+		fmgr_info_set_expr((Node *) serialfnexpr, &pertrans->serialfn);
+
+		pertrans->serialfn_fcinfo =
+			(FunctionCallInfo) palloc(SizeForFunctionCallInfo(1));
+		InitFunctionCallInfoData(*pertrans->serialfn_fcinfo,
+								 &pertrans->serialfn,
+								 1,
+								 InvalidOid,
+								 (void *) aggstate, NULL);
+	}
+
+	if (OidIsValid(aggdeserialfn))
+	{
+		build_aggregate_deserialfn_expr(aggdeserialfn,
+										&deserialfnexpr);
+		fmgr_info(aggdeserialfn, &pertrans->deserialfn);
+		fmgr_info_set_expr((Node *) deserialfnexpr, &pertrans->deserialfn);
+
+		pertrans->deserialfn_fcinfo =
+			(FunctionCallInfo) palloc(SizeForFunctionCallInfo(2));
+		InitFunctionCallInfoData(*pertrans->deserialfn_fcinfo,
+								 &pertrans->deserialfn,
+								 2,
+								 InvalidOid,
+								 (void *) aggstate, NULL);
+	}
+
+	/*
+	 * If we're doing either DISTINCT or ORDER BY for a plain agg, then we
+	 * have a list of SortGroupClause nodes; fish out the data in them and
+	 * stick them into arrays.  We ignore ORDER BY for an ordered-set agg,
+	 * however; the agg's transfn and finalfn are responsible for that.
+	 *
+	 * Note that by construction, if there is a DISTINCT clause then the ORDER
+	 * BY clause is a prefix of it (see transformDistinctClause).
+	 */
+	if (AGGKIND_IS_ORDERED_SET(aggref->aggkind))
+	{
+		sortlist = NIL;
+		numSortCols = numDistinctCols = 0;
+	}
+	else if (aggref->aggdistinct)
+	{
+		sortlist = aggref->aggdistinct;
+		numSortCols = numDistinctCols = list_length(sortlist);
+		Assert(numSortCols >= list_length(aggref->aggorder));
+	}
+	else
+	{
+		sortlist = aggref->aggorder;
+		numSortCols = list_length(sortlist);
+		numDistinctCols = 0;
+	}
+
+	pertrans->numSortCols = numSortCols;
+	pertrans->numDistinctCols = numDistinctCols;
+
+	/*
+	 * If we have either sorting or filtering to do, create a tupledesc and
+	 * slot corresponding to the aggregated inputs (including sort
+	 * expressions) of the agg.
+	 */
+	if (numSortCols > 0 || aggref->aggfilter)
+	{
+		pertrans->sortdesc = ExecTypeFromTL(aggref->args);
+		pertrans->sortslot =
+			ExecInitExtraTupleSlot(estate, pertrans->sortdesc,
+								   &TTSOpsMinimalTuple);
+	}
+
+	if (numSortCols > 0)
+	{
+		/*
+		 * We don't implement DISTINCT or ORDER BY aggs in the HASHED case
+		 * (yet)
+		 */
+		Assert(aggstate->aggstrategy != AGG_HASHED && aggstate->aggstrategy != AGG_MIXED);
+
+#if PG_VERSION_NUM >= PG_VERSION_15
+		/* ORDER BY aggregates are not supported with partial aggregation */
+		Assert(!DO_AGGSPLIT_COMBINE(aggstate->aggsplit));
+#endif
+
+		/* If we have only one input, we need its len/byval info. */
+		if (numInputs == 1)
+		{
+			get_typlenbyval(inputTypes[numDirectArgs],
+							&pertrans->inputtypeLen,
+							&pertrans->inputtypeByVal);
+		}
+		else if (numDistinctCols > 0)
+		{
+			/* we will need an extra slot to store prior values */
+			pertrans->uniqslot =
+				ExecInitExtraTupleSlot(estate, pertrans->sortdesc,
+									   &TTSOpsMinimalTuple);
+		}
+
+		/* Extract the sort information for use later */
+		pertrans->sortColIdx =
+			(AttrNumber *) palloc(numSortCols * sizeof(AttrNumber));
+		pertrans->sortOperators =
+			(Oid *) palloc(numSortCols * sizeof(Oid));
+		pertrans->sortCollations =
+			(Oid *) palloc(numSortCols * sizeof(Oid));
+		pertrans->sortNullsFirst =
+			(bool *) palloc(numSortCols * sizeof(bool));
+
+		i = 0;
+		foreach(lc, sortlist)
+		{
+			SortGroupClause *sortcl = (SortGroupClause *) lfirst(lc);
+			TargetEntry *tle = get_sortgroupclause_tle(sortcl, aggref->args);
+
+			/* the parser should have made sure of this */
+			Assert(OidIsValid(sortcl->sortop));
+
+			pertrans->sortColIdx[i] = tle->resno;
+			pertrans->sortOperators[i] = sortcl->sortop;
+			pertrans->sortCollations[i] = exprCollation((Node *) tle->expr);
+			pertrans->sortNullsFirst[i] = sortcl->nulls_first;
+			i++;
+		}
+		Assert(i == numSortCols);
+	}
+
+	if (aggref->aggdistinct)
+	{
+		Oid		   *ops;
+
+		Assert(numArguments > 0);
+		Assert(list_length(aggref->aggdistinct) == numDistinctCols);
+
+		ops = palloc(numDistinctCols * sizeof(Oid));
+
+		i = 0;
+		foreach(lc, aggref->aggdistinct)
+			ops[i++] = ((SortGroupClause *) lfirst(lc))->eqop;
+
+		/* lookup / build the necessary comparators */
+		if (numDistinctCols == 1)
+			fmgr_info(get_opcode(ops[0]), &pertrans->equalfnOne);
+		else
+			pertrans->equalfnMulti =
+				execTuplesMatchPrepare(pertrans->sortdesc,
+									   numDistinctCols,
+									   pertrans->sortColIdx,
+									   ops,
+									   pertrans->sortCollations,
+									   &aggstate->ss.ps);
+		pfree(ops);
+	}
+
+	pertrans->sortstates = (Tuplesortstate **)
+		palloc0(sizeof(Tuplesortstate *) * numGroupingSets);
+}
+
+
+static Datum
+GetAggInitVal(Datum textInitVal, Oid transtype)
+{
+	Oid			typinput,
+				typioparam;
+	char	   *strInitVal;
+	Datum		initVal;
+
+	getTypeInputInfo(transtype, &typinput, &typioparam);
+	strInitVal = TextDatumGetCString(textInitVal);
+	initVal = OidInputFunctionCall(typinput, strInitVal,
+								   typioparam, -1);
+	pfree(strInitVal);
+	return initVal;
+}
+
+void
+ExecEndAgg(AggState *node)
+{
+	PlanState  *outerPlan;
+	int			transno;
+	int			numGroupingSets = Max(node->maxsets, 1);
+	int			setno;
+
+	/*
+	 * When ending a parallel worker, copy the statistics gathered by the
+	 * worker back into shared memory so that it can be picked up by the main
+	 * process to report in EXPLAIN ANALYZE.
+	 */
+	if (node->shared_info && IsParallelWorker())
+	{
+		AggregateInstrumentation *si;
+
+		Assert(ParallelWorkerNumber <= node->shared_info->num_workers);
+		si = &node->shared_info->sinstrument[ParallelWorkerNumber];
+		si->hash_batches_used = node->hash_batches_used;
+		si->hash_disk_used = node->hash_disk_used;
+		si->hash_mem_peak = node->hash_mem_peak;
+	}
+
+	/* Make sure we have closed any open tuplesorts */
+
+	if (node->sort_in)
+		tuplesort_end(node->sort_in);
+	if (node->sort_out)
+		tuplesort_end(node->sort_out);
+
+	hashagg_reset_spill_state(node);
+
+	if (node->hash_metacxt != NULL)
+	{
+		MemoryContextDelete(node->hash_metacxt);
+		node->hash_metacxt = NULL;
+	}
+
+	for (transno = 0; transno < node->numtrans; transno++)
+	{
+		AggStatePerTrans pertrans = &node->pertrans[transno];
+
+		for (setno = 0; setno < numGroupingSets; setno++)
+		{
+			if (pertrans->sortstates[setno])
+				tuplesort_end(pertrans->sortstates[setno]);
+		}
+	}
+
+	/* And ensure any agg shutdown callbacks have been called */
+	for (setno = 0; setno < numGroupingSets; setno++)
+		ReScanExprContext(node->aggcontexts[setno]);
+	if (node->hashcontext)
+		ReScanExprContext(node->hashcontext);
+
+	/*
+	 * We don't actually free any ExprContexts here (see comment in
+	 * ExecFreeExprContext), just unlinking the output one from the plan node
+	 * suffices.
+	 */
+	ExecFreeExprContext(&node->ss.ps);
+
+	/* clean up tuple table */
+	ExecClearTuple(node->ss.ss_ScanTupleSlot);
+
+	outerPlan = outerPlanState(node);
+	ExecEndNode(outerPlan);
+}
+
+void
+ExecReScanAgg(AggState *node)
+{
+	ExprContext *econtext = node->ss.ps.ps_ExprContext;
+	PlanState  *outerPlan = outerPlanState(node);
+	Agg		   *aggnode = (Agg *) node->ss.ps.plan;
+	int			transno;
+	int			numGroupingSets = Max(node->maxsets, 1);
+	int			setno;
+
+	node->agg_done = false;
+
+	if (node->aggstrategy == AGG_HASHED)
+	{
+		/*
+		 * In the hashed case, if we haven't yet built the hash table then we
+		 * can just return; nothing done yet, so nothing to undo. If subnode's
+		 * chgParam is not NULL then it will be re-scanned by ExecProcNode,
+		 * else no reason to re-scan it at all.
+		 */
+		if (!node->table_filled)
+			return;
+
+		/*
+		 * If we do have the hash table, and it never spilled, and the subplan
+		 * does not have any parameter changes, and none of our own parameter
+		 * changes affect input expressions of the aggregated functions, then
+		 * we can just rescan the existing hash table; no need to build it
+		 * again.
+		 */
+		if (outerPlan->chgParam == NULL && !node->hash_ever_spilled &&
+			!bms_overlap(node->ss.ps.chgParam, aggnode->aggParams))
+		{
+			ResetTupleHashIterator(node->perhash[0].hashtable,
+								   &node->perhash[0].hashiter);
+			select_current_set(node, 0, true);
+			return;
+		}
+	}
+
+	/* Make sure we have closed any open tuplesorts */
+	for (transno = 0; transno < node->numtrans; transno++)
+	{
+		for (setno = 0; setno < numGroupingSets; setno++)
+		{
+			AggStatePerTrans pertrans = &node->pertrans[transno];
+
+			if (pertrans->sortstates[setno])
+			{
+				tuplesort_end(pertrans->sortstates[setno]);
+				pertrans->sortstates[setno] = NULL;
+			}
+		}
+	}
+
+	/*
+	 * We don't need to ReScanExprContext the output tuple context here;
+	 * ExecReScan already did it. But we do need to reset our per-grouping-set
+	 * contexts, which may have transvalues stored in them. (We use rescan
+	 * rather than just reset because transfns may have registered callbacks
+	 * that need to be run now.) For the AGG_HASHED case, see below.
+	 */
+
+	for (setno = 0; setno < numGroupingSets; setno++)
+	{
+		ReScanExprContext(node->aggcontexts[setno]);
+	}
+
+	/* Release first tuple of group, if we have made a copy */
+	if (node->grp_firstTuple != NULL)
+	{
+		heap_freetuple(node->grp_firstTuple);
+		node->grp_firstTuple = NULL;
+	}
+	ExecClearTuple(node->ss.ss_ScanTupleSlot);
+
+	/* Forget current agg values */
+	MemSet(econtext->ecxt_aggvalues, 0, sizeof(Datum) * node->numaggs);
+	MemSet(econtext->ecxt_aggnulls, 0, sizeof(bool) * node->numaggs);
+
+	/*
+	 * With AGG_HASHED/MIXED, the hash table is allocated in a sub-context of
+	 * the hashcontext. This used to be an issue, but now, resetting a context
+	 * automatically deletes sub-contexts too.
+	 */
+	if (node->aggstrategy == AGG_HASHED || node->aggstrategy == AGG_MIXED)
+	{
+		hashagg_reset_spill_state(node);
+
+		node->hash_ever_spilled = false;
+		node->hash_spill_mode = false;
+		node->hash_ngroups_current = 0;
+
+		ReScanExprContext(node->hashcontext);
+		/* Rebuild an empty hash table */
+		build_hash_tables(node);
+		node->table_filled = false;
+		/* iterator will be reset when the table is filled */
+
+		hashagg_recompile_expressions(node, false, false);
+	}
+
+	if (node->aggstrategy != AGG_HASHED)
+	{
+		/*
+		 * Reset the per-group state (in particular, mark transvalues null)
+		 */
+		for (setno = 0; setno < numGroupingSets; setno++)
+		{
+			MemSet(node->pergroups[setno], 0,
+				   sizeof(AggStatePerGroupData) * node->numaggs);
+		}
+
+		/* reset to phase 1 */
+		initialize_phase(node, 1);
+
+		node->input_done = false;
+		node->projected_set = -1;
+	}
+
+	if (outerPlan->chgParam == NULL)
+		ExecReScan(outerPlan);
+}
+
+
+/***********************************************************************
+ * API exposed to aggregate functions
+ ***********************************************************************/
+
+
+/*
+ * AggCheckCallContext - test if a SQL function is being called as an aggregate
+ *
+ * The transition and/or final functions of an aggregate may want to verify
+ * that they are being called as aggregates, rather than as plain SQL
+ * functions.  They should use this function to do so.  The return value
+ * is nonzero if being called as an aggregate, or zero if not.  (Specific
+ * nonzero values are AGG_CONTEXT_AGGREGATE or AGG_CONTEXT_WINDOW, but more
+ * values could conceivably appear in future.)
+ *
+ * If aggcontext isn't NULL, the function also stores at *aggcontext the
+ * identity of the memory context that aggregate transition values are being
+ * stored in.  Note that the same aggregate call site (flinfo) may be called
+ * interleaved on different transition values in different contexts, so it's
+ * not kosher to cache aggcontext under fn_extra.  It is, however, kosher to
+ * cache it in the transvalue itself (for internal-type transvalues).
+ */
+int
+AggCheckCallContext(FunctionCallInfo fcinfo, MemoryContext *aggcontext)
+{
+	if (fcinfo->context && IsA(fcinfo->context, AggState))
+	{
+		if (aggcontext)
+		{
+			AggState   *aggstate = ((AggState *) fcinfo->context);
+			ExprContext *cxt = aggstate->curaggcontext;
+
+			*aggcontext = cxt->ecxt_per_tuple_memory;
+		}
+		return AGG_CONTEXT_AGGREGATE;
+	}
+	if (fcinfo->context && IsA(fcinfo->context, WindowAggState))
+	{
+		if (aggcontext)
+			*aggcontext = ((WindowAggState *) fcinfo->context)->curaggcontext;
+		return AGG_CONTEXT_WINDOW;
+	}
+
+	/* this is just to prevent "uninitialized variable" warnings */
+	if (aggcontext)
+		*aggcontext = NULL;
+	return 0;
+}
+
+/*
+ * AggGetAggref - allow an aggregate support function to get its Aggref
+ *
+ * If the function is being called as an aggregate support function,
+ * return the Aggref node for the aggregate call.  Otherwise, return NULL.
+ *
+ * Aggregates sharing the same inputs and transition functions can get
+ * merged into a single transition calculation.  If the transition function
+ * calls AggGetAggref, it will get some one of the Aggrefs for which it is
+ * executing.  It must therefore not pay attention to the Aggref fields that
+ * relate to the final function, as those are indeterminate.  But if a final
+ * function calls AggGetAggref, it will get a precise result.
+ *
+ * Note that if an aggregate is being used as a window function, this will
+ * return NULL.  We could provide a similar function to return the relevant
+ * WindowFunc node in such cases, but it's not needed yet.
+ */
+Aggref *
+AggGetAggref(FunctionCallInfo fcinfo)
+{
+	if (fcinfo->context && IsA(fcinfo->context, AggState))
+	{
+		AggState   *aggstate = (AggState *) fcinfo->context;
+		AggStatePerAgg curperagg;
+		AggStatePerTrans curpertrans;
+
+		/* check curperagg (valid when in a final function) */
+		curperagg = aggstate->curperagg;
+
+		if (curperagg)
+			return curperagg->aggref;
+
+		/* check curpertrans (valid when in a transition function) */
+		curpertrans = aggstate->curpertrans;
+
+		if (curpertrans)
+			return curpertrans->aggref;
+	}
+	return NULL;
+}
+
+#if PG_VERSION_NUM < PG_VERSION_15
+/*
+
+ * AggGetTempMemoryContext - fetch short-term memory context for aggregates
+ *
+ * This is useful in agg final functions; the context returned is one that
+ * the final function can safely reset as desired.  This isn't useful for
+ * transition functions, since the context returned MAY (we don't promise)
+ * be the same as the context those are called in.
+ *
+ * As above, this is currently not useful for aggs called as window functions.
+ */
+MemoryContext
+AggGetTempMemoryContext(FunctionCallInfo fcinfo)
+{
+	if (fcinfo->context && IsA(fcinfo->context, AggState))
+	{
+		AggState   *aggstate = (AggState *) fcinfo->context;
+
+		return aggstate->tmpcontext->ecxt_per_tuple_memory;
+	}
+	return NULL;
+}
+#endif
+
+/*
+ * AggStateIsShared - find out whether transition state is shared
+ *
+ * If the function is being called as an aggregate support function,
+ * return true if the aggregate's transition state is shared across
+ * multiple aggregates, false if it is not.
+ *
+ * Returns true if not called as an aggregate support function.
+ * This is intended as a conservative answer, ie "no you'd better not
+ * scribble on your input".  In particular, will return true if the
+ * aggregate is being used as a window function, which is a scenario
+ * in which changing the transition state is a bad idea.  We might
+ * want to refine the behavior for the window case in future.
+ */
+bool
+AggStateIsShared(FunctionCallInfo fcinfo)
+{
+	if (fcinfo->context && IsA(fcinfo->context, AggState))
+	{
+		AggState   *aggstate = (AggState *) fcinfo->context;
+		AggStatePerAgg curperagg;
+		AggStatePerTrans curpertrans;
+
+		/* check curperagg (valid when in a final function) */
+		curperagg = aggstate->curperagg;
+
+		if (curperagg)
+			return aggstate->pertrans[curperagg->transno].aggshared;
+
+		/* check curpertrans (valid when in a transition function) */
+		curpertrans = aggstate->curpertrans;
+
+		if (curpertrans)
+			return curpertrans->aggshared;
+	}
+	return true;
+}
+
+#if PG_VERSION_NUM < PG_VERSION_15
+/*
+ * AggRegisterCallback - register a cleanup callback for an aggregate
+ *
+ * This is useful for aggs to register shutdown callbacks, which will ensure
+ * that non-memory resources are freed.  The callback will occur just before
+ * the associated aggcontext (as returned by AggCheckCallContext) is reset,
+ * either between groups or as a result of rescanning the query.  The callback
+ * will NOT be called on error paths.  The typical use-case is for freeing of
+ * tuplestores or tuplesorts maintained in aggcontext, or pins held by slots
+ * created by the agg functions.  (The callback will not be called until after
+ * the result of the finalfn is no longer needed, so it's safe for the finalfn
+ * to return data that will be freed by the callback.)
+ *
+ * As above, this is currently not useful for aggs called as window functions.
+ */
+void
+AggRegisterCallback(FunctionCallInfo fcinfo,
+					ExprContextCallbackFunction func,
+					Datum arg)
+{
+	if (fcinfo->context && IsA(fcinfo->context, AggState))
+	{
+		AggState   *aggstate = (AggState *) fcinfo->context;
+		ExprContext *cxt = aggstate->curaggcontext;
+
+		RegisterExprContextCallback(cxt, func, arg);
+
+		return;
+	}
+	elog(ERROR, "aggregate function cannot register a callback in this context");
+}
+#endif
+
+/* ----------------------------------------------------------------
+ *						Parallel Query Support
+ * ----------------------------------------------------------------
+ */
+
+/* Parallel Execution */
+
+static Size 
+ColumnarAggNode_EstimateDSM(CustomScanState *node,
+							ParallelContext *pcxt)
+{
+	Size nbytes = 0;
+	return nbytes;
+}
+
+
+static void 
+ColumnarAggNode_InitializeDSM(CustomScanState *node,
+							  ParallelContext *pcxt,
+							  void *coordinate)
+{
+}
+
+
+static void 
+ColumnarAggNode_ReinitializeDSM(CustomScanState *node,
+								ParallelContext *pcxt,
+								void *coordinate)
+{
+}
+
+
+static void 
+ColumnarAggNode_InitializeWorker(CustomScanState *node,
+								 shm_toc *toc,
+								 void *coordinate)
+{
+}
+
+/* CustomScan Aggregator Node */
+#include "nodes/extensible.h"
+
+
+/* CustomScanMethods */
+static Node *CreateVectorAggState(CustomScan *custom_plan);
+
+/* CustomScanExecMethods */
+static void BeginVectorAgg(CustomScanState *node, EState *estate, int eflags);
+static TupleTableSlot *ExecVectorAgg(CustomScanState *node);
+static void EndVectorAgg(CustomScanState *node);
+static void ExplainAggNode(CustomScanState *node, List *ancestors, ExplainState *es);
+
+static CustomScanMethods VectorAggNodeMethods = {
+	"VectorAggNode",		/* CustomName */
+	CreateVectorAggState,	/* CreateCustomScanState */
+};
+
+static CustomExecMethods VectorAggNodeExecMethods = {
+	.CustomName = "VectorAggNode",
+
+	.BeginCustomScan = BeginVectorAgg,
+	.ExecCustomScan = ExecVectorAgg,
+	.EndCustomScan = EndVectorAgg,
+
+	.ExplainCustomScan = ExplainAggNode,
+
+	.EstimateDSMCustomScan = ColumnarAggNode_EstimateDSM,
+	.InitializeDSMCustomScan = ColumnarAggNode_InitializeDSM,
+	.ReInitializeDSMCustomScan = ColumnarAggNode_ReinitializeDSM,
+	.InitializeWorkerCustomScan = ColumnarAggNode_InitializeWorker
+};
+
+
+static Node *
+CreateVectorAggState(CustomScan *custom_plan)
+{
+	VectorAggState *vas = (VectorAggState *) newNode(
+		sizeof(VectorAggState), T_CustomScanState);
+
+	CustomScanState *cscanstate = &vas->css;
+	cscanstate->methods = &VectorAggNodeExecMethods;
+
+	return (Node *) cscanstate;
+}
+
+
+static void
+BeginVectorAgg(CustomScanState *css, EState *estate, int eflags)
+{
+	VectorAggState *vas = (VectorAggState*) css;
+	CustomScan  *cscan = (CustomScan *)css->ss.ps.plan;
+	Agg	*aggNode = (Agg *)linitial(cscan->custom_plans);
+
+	/* Free the exprcontext */
+	ExecFreeExprContext(&css->ss.ps);
+
+	/* Clean out the tuple table */
+	ExecClearTuple(css->ss.ps.ps_ResultTupleSlot);
+	ExecClearTuple(css->ss.ss_ScanTupleSlot);
+
+
+	vas->aggstate = VExecInitAgg(aggNode, estate, eflags);
+
+	// HYDRA: add leftree to custom agg
+	outerPlanState(vas) = outerPlanState(vas->aggstate);
+
+	 /*Initialize result type and projection. */
+	ExecInitResultTypeTL(&vas->css.ss.ps);
+
+	vas->css.ss.ps.ps_ResultTupleSlot = vas->aggstate->ss.ps.ps_ResultTupleSlot;
+}
+
+
+static TupleTableSlot *
+ExecVectorAgg(CustomScanState *node)
+{
+	return ExecAgg((PlanState *)node);
+}
+
+
+static void
+EndVectorAgg(CustomScanState *node)
+{
+	ExecEndAgg(((VectorAggState *)node)->aggstate);
+}
+
+
+static void
+ExplainAggNode(CustomScanState *node, List *ancestors, ExplainState *es)
+{
+
+}
+
+
+CustomScan *
+columnar_create_aggregator_node(void)
+{
+	CustomScan *cscan = (CustomScan *) makeNode(CustomScan);
+	cscan->methods = &VectorAggNodeMethods;
+	return cscan;
+}
+
+
+void
+columnar_register_aggregator_node(void)
+{
+	RegisterCustomScanMethods(&VectorAggNodeMethods);
+}
+
+#endif

--- a/columnar/src/backend/columnar/vectorization/types/aggregates.c
+++ b/columnar/src/backend/columnar/vectorization/types/aggregates.c
@@ -1,0 +1,457 @@
+
+#include "postgres.h"
+
+#include "fmgr.h"
+#include "nodes/execnodes.h"
+#include "utils/date.h"
+#include "utils/array.h"
+#include "utils/numeric.h"
+#include "utils/fmgrprotos.h"
+
+#include "pg_version_constants.h"
+#include "columnar/vectorization/types/types.h"
+#include "columnar/vectorization/types/numeric.h"
+
+/* count */
+
+PG_FUNCTION_INFO_V1(vemptycount);
+Datum vemptycount(PG_FUNCTION_ARGS)
+{
+	int64 arg = PG_GETARG_INT64(0);
+	PG_RETURN_INT64(arg);
+}
+
+PG_FUNCTION_INFO_V1(vanycount);
+Datum
+vanycount(PG_FUNCTION_ARGS)
+{
+	int64 arg = PG_GETARG_INT64(0);
+	int64 result = arg;
+	VectorColumn *arg1 = (VectorColumn *) PG_GETARG_POINTER(1);
+	int i;
+
+	for (i = 0; i <  arg1->dimension; i++) 
+	{
+		if (arg1->isnull[i])
+			continue;
+
+		result++;
+	}
+
+	PG_RETURN_INT64(result);
+}
+
+/* int2 */
+
+PG_FUNCTION_INFO_V1(vint2sum);
+Datum
+vint2sum(PG_FUNCTION_ARGS)
+{
+	int64 sumX = PG_GETARG_INT64(0);
+	VectorColumn *arg1 = (VectorColumn*) PG_GETARG_POINTER(1);
+	int i;
+
+	int16 *vectorValue = (int16*) arg1->value;
+
+	for (i = 0; i < arg1->dimension; i++)
+	{
+		if (!arg1->isnull[i])
+			sumX += (int64) vectorValue[i];
+	}
+
+	PG_RETURN_INT64(sumX);
+}
+
+PG_FUNCTION_INFO_V1(vint2acc);
+Datum
+vint2acc(PG_FUNCTION_ARGS)
+{
+	ArrayType  *transarray;
+	VectorColumn *arg1 = (VectorColumn*) PG_GETARG_POINTER(1);
+	Int64AggState *transdata;
+	int i;
+
+	/*
+	 * If we're invoked as an aggregate, we can cheat and modify our first
+	 * parameter in-place to reduce palloc overhead. Otherwise we need to make
+	 * a copy of it before scribbling on it.
+	 */
+	if (AggCheckCallContext(fcinfo, NULL))
+		transarray = PG_GETARG_ARRAYTYPE_P(0);
+	else
+		transarray = PG_GETARG_ARRAYTYPE_P_COPY(0);
+
+	transdata = (Int64AggState *) ARR_DATA_PTR(transarray);
+
+	int16 *vectorValue = (int16*) arg1->value;
+
+	for (i = 0; i < arg1->dimension; i++)
+	{
+		if (!arg1->isnull[i])
+		{
+			transdata->N++;
+			transdata->sumX += (int64) vectorValue[i];
+		}
+	}
+
+	PG_RETURN_ARRAYTYPE_P(transarray);
+}
+
+PG_FUNCTION_INFO_V1(vint2larger);
+Datum vint2larger(PG_FUNCTION_ARGS)
+{
+	int16 maxValue = PG_GETARG_INT16(0);
+	VectorColumn *arg2 = (VectorColumn*) PG_GETARG_POINTER(1);
+	int16 result = maxValue;
+	int i = 0;
+
+	int16 *vectorValue = (int16*) arg2->value;
+
+	for (i = 0; i < arg2->dimension; i++) 
+	{
+		if (arg2->isnull[i])
+			continue;
+
+		result = Max(result, vectorValue[i]);
+	}
+
+	maxValue = Max(maxValue, result);
+
+	PG_RETURN_INT16(maxValue);
+}
+
+PG_FUNCTION_INFO_V1(vint2smaller);
+Datum vint2smaller(PG_FUNCTION_ARGS)
+{
+	int16 minValue = PG_GETARG_INT32(0);
+	VectorColumn *arg2 = (VectorColumn*) PG_GETARG_POINTER(1);
+	int16 result = minValue;
+	int i = 0;
+
+	int16 *vectorValue = (int16*) arg2->value;
+
+	for (i = 0; i < arg2->dimension; i++) 
+	{
+		if (arg2->isnull[i])
+			continue;
+
+		result = Min(result, vectorValue[i]);
+	}
+
+	minValue = Min(minValue, result);
+
+	PG_RETURN_INT16(minValue);
+}
+
+/* int4 */
+
+PG_FUNCTION_INFO_V1(vint4sum);
+Datum
+vint4sum(PG_FUNCTION_ARGS)
+{
+	int64 sumX = PG_GETARG_INT64(0);
+	VectorColumn *arg1 = (VectorColumn*) PG_GETARG_POINTER(1);
+	int i;
+
+	int32 *vectorValue = (int32*) arg1->value;
+
+	for (i = 0; i < arg1->dimension; i++)
+	{
+		if (!arg1->isnull[i])
+			sumX += (int64) vectorValue[i];
+	}
+
+	PG_RETURN_INT64(sumX);
+}
+
+PG_FUNCTION_INFO_V1(vint4acc);
+Datum
+vint4acc(PG_FUNCTION_ARGS)
+{
+	ArrayType  *transarray;
+	VectorColumn *arg1 = (VectorColumn*) PG_GETARG_POINTER(1);
+	Int64AggState *transdata;
+	int i;
+
+	/*
+	 * If we're invoked as an aggregate, we can cheat and modify our first
+	 * parameter in-place to reduce palloc overhead. Otherwise we need to make
+	 * a copy of it before scribbling on it.
+	 */
+	if (AggCheckCallContext(fcinfo, NULL))
+		transarray = PG_GETARG_ARRAYTYPE_P(0);
+	else
+		transarray = PG_GETARG_ARRAYTYPE_P_COPY(0);
+
+	transdata = (Int64AggState *) ARR_DATA_PTR(transarray);
+
+	int32 *vectorValue = (int32*) arg1->value;
+
+	for (i = 0; i < arg1->dimension; i++)
+	{
+		if (!arg1->isnull[i])
+		{
+			transdata->N++;
+			transdata->sumX += (int64) vectorValue[i];
+		}
+	}
+
+	PG_RETURN_ARRAYTYPE_P(transarray);
+}
+
+PG_FUNCTION_INFO_V1(vint4larger);
+Datum vint4larger(PG_FUNCTION_ARGS)
+{
+	int32 maxValue = PG_GETARG_INT32(0);
+	VectorColumn *arg2 = (VectorColumn*) PG_GETARG_POINTER(1);
+	int32 result = maxValue;
+	int i = 0;
+
+	int32 *vectorValue = (int32*) arg2->value;
+
+	for (i = 0; i < arg2->dimension; i++) 
+	{
+		if (arg2->isnull[i])
+			continue;
+
+		result = Max(result, vectorValue[i]);
+	}
+
+	maxValue = Max(maxValue, result);
+
+	PG_RETURN_INT32(maxValue);
+}
+
+PG_FUNCTION_INFO_V1(vint4smaller);
+Datum vint4smaller(PG_FUNCTION_ARGS)
+{
+	int32 minValue = PG_GETARG_INT32(0);
+	VectorColumn *arg2 = (VectorColumn*) PG_GETARG_POINTER(1);
+	int32 result = minValue;
+	int i = 0;
+
+	int32 *vectorValue = (int32*) arg2->value;
+
+	for (i = 0; i < arg2->dimension; i++) 
+	{
+		if (arg2->isnull[i])
+			continue;
+
+		result = Min(result, vectorValue[i]);
+	}
+
+	minValue = Min(minValue, result);
+
+	PG_RETURN_INT32(minValue);
+}
+
+/* int2 / int4 */
+
+PG_FUNCTION_INFO_V1(vint2int4avg);
+Datum
+vint2int4avg(PG_FUNCTION_ARGS)
+{
+	ArrayType  *transarray = PG_GETARG_ARRAYTYPE_P(0);
+	Int64AggState *transdata;
+
+	if (ARR_HASNULL(transarray) ||
+		ARR_SIZE(transarray) != ARR_OVERHEAD_NONULLS(1) + sizeof(Int64AggState))
+		elog(ERROR, "expected 2-element int8 array");
+
+	transdata = (Int64AggState *) ARR_DATA_PTR(transarray);
+
+	/* SQL defines AVG of no values to be NULL */
+	if (transdata->N == 0)
+		PG_RETURN_NULL();
+
+#if PG_VERSION_NUM >= PG_VERSION_14
+	Numeric sumNumeric, nNumeric, res;
+	nNumeric = int64_to_numeric(transdata->N);
+	sumNumeric = int64_to_numeric(transdata->sumX);
+	res = numeric_div_opt_error(sumNumeric, nNumeric, NULL);
+	PG_RETURN_NUMERIC(res);
+#else
+	Datum countd, sumd;
+	countd = DirectFunctionCall1(int8_numeric,
+								 Int64GetDatumFast(transdata->N));
+	sumd = DirectFunctionCall1(int8_numeric,
+							   Int64GetDatumFast(transdata->sumX));
+	PG_RETURN_DATUM(DirectFunctionCall2(numeric_div, sumd, countd));
+#endif
+
+}
+
+
+/* int8 */
+
+PG_FUNCTION_INFO_V1(vint8acc);
+Datum
+vint8acc(PG_FUNCTION_ARGS)
+{
+	Int128AggState *state;
+	int i;
+
+	state = PG_ARGISNULL(0) ? NULL : (Int128AggState *) PG_GETARG_POINTER(0);
+	VectorColumn *arg1 = (VectorColumn*) PG_GETARG_POINTER(1);
+
+	MemoryContext aggContext;
+	MemoryContext oldContext;
+
+	if (!AggCheckCallContext(fcinfo, &aggContext))
+		elog(ERROR, "aggregate function called in non-aggregate context");
+
+	oldContext = MemoryContextSwitchTo(aggContext);
+
+	/* Create the state data on the first call */
+	if (state == NULL)
+	{
+		state = palloc0(sizeof(Int128AggState));
+		state->calcSumX2 = false;
+	}
+
+	int64 *vectorValue = (int64*) arg1->value;
+
+	for (i = 0; i < arg1->dimension; i++)
+	{
+		if (!arg1->isnull[i])
+		{
+			state->N++;
+			state->sumX += (int128) vectorValue[i];
+		}
+	}
+
+	MemoryContextSwitchTo(oldContext);
+
+	PG_RETURN_NUMERIC(state);
+}
+
+PG_FUNCTION_INFO_V1(vint8sum);
+Datum
+vint8sum(PG_FUNCTION_ARGS)
+{
+	Int128AggState *state;
+
+	state = PG_ARGISNULL(0) ? NULL : (Int128AggState *) PG_GETARG_POINTER(0);
+
+	/* If there were no non-null inputs, return NULL */
+	if (state == NULL || state->N == 0)
+		PG_RETURN_NULL();
+
+	Numeric res = int128_to_numeric(state->sumX);
+
+	PG_RETURN_NUMERIC(res);
+}
+
+PG_FUNCTION_INFO_V1(vint8avg);
+Datum
+vint8avg(PG_FUNCTION_ARGS)
+{
+	Int128AggState *state;
+	Numeric sumNumeric, nNumeric, res;
+
+	state = PG_ARGISNULL(0) ? NULL : (Int128AggState *) PG_GETARG_POINTER(0);
+
+	/* If there were no non-null inputs, return NULL */
+	if (state == NULL || state->N == 0)
+		PG_RETURN_NULL();
+
+	sumNumeric = int128_to_numeric(state->sumX);
+	nNumeric = int128_to_numeric(state->N);
+	res = numeric_div_opt_error(sumNumeric, nNumeric, NULL);
+
+	PG_RETURN_NUMERIC(res);
+}
+
+PG_FUNCTION_INFO_V1(vint8larger);
+Datum vint8larger(PG_FUNCTION_ARGS)
+{
+	int64 maxValue = PG_GETARG_INT64(0);
+	VectorColumn *arg2 = (VectorColumn*) PG_GETARG_POINTER(1);
+	int64 result = 0;
+	int i = 0;
+
+	int64 *vectorValue = (int64*) arg2->value;
+
+	for (i = 0; i < arg2->dimension; i++) 
+	{
+		if (arg2->isnull[i])
+			continue;
+
+		result = Max(maxValue, vectorValue[i]);
+	}
+
+	maxValue = Max(maxValue, result);
+
+	PG_RETURN_INT64(maxValue);
+}
+
+PG_FUNCTION_INFO_V1(vint8smaller);
+Datum vint8smaller(PG_FUNCTION_ARGS)
+{
+	int64 minValue = PG_GETARG_INT64(0);
+	VectorColumn *arg2 = (VectorColumn*) PG_GETARG_POINTER(1);
+	int64 result = minValue;
+	int i = 0;
+
+	int64 *vectorValue = (int64*) arg2->value;
+
+	for (i = 0; i < arg2->dimension; i++) 
+	{
+		if (arg2->isnull[i])
+			continue;
+
+		result = Min(result, vectorValue[i]);
+	}
+
+	minValue = Min(minValue, result);
+
+	PG_RETURN_INT64(minValue);
+}
+
+// date
+
+PG_FUNCTION_INFO_V1(vdatelarger);
+Datum vdatelarger(PG_FUNCTION_ARGS)
+{
+	int32 maxValue = PG_GETARG_INT32(0);
+	VectorColumn *arg2 = (VectorColumn*) PG_GETARG_POINTER(1);
+	int32 result = maxValue;
+	int i = 0;
+
+	DateADT *vectorValue = (DateADT*) arg2->value;
+
+	for (i = 0; i < arg2->dimension; i++) 
+	{
+		if (arg2->isnull[i])
+			continue;
+
+		result = Max(result, vectorValue[i]);
+	}
+
+	maxValue = Max(maxValue, result);
+
+	PG_RETURN_INT32(maxValue);
+}
+
+PG_FUNCTION_INFO_V1(vdatesmaller);
+Datum vdatesmaller(PG_FUNCTION_ARGS)
+{
+	int32 minValue = PG_GETARG_INT32(0);
+	VectorColumn *arg2 = (VectorColumn*) PG_GETARG_POINTER(1);
+	int32 result = minValue;
+	int i = 0;
+
+	DateADT *vectorValue = (DateADT*) arg2->value;
+
+	for (i = 0; i < arg2->dimension; i++) 
+	{
+		if (arg2->isnull[i])
+			continue;
+
+		result = Min(result, vectorValue[i]);
+	}
+
+	minValue = Min(minValue, result);
+
+	PG_RETURN_INT32(minValue);
+}

--- a/columnar/src/backend/columnar/vectorization/types/int.c
+++ b/columnar/src/backend/columnar/vectorization/types/int.c
@@ -1,5 +1,6 @@
 
 #include "postgres.h"
+#include "common/int.h"
 
 #include "fmgr.h"
 #include "nodes/execnodes.h"

--- a/columnar/src/backend/columnar/vectorization/types/numeric.c
+++ b/columnar/src/backend/columnar/vectorization/types/numeric.c
@@ -1,0 +1,451 @@
+/*-------------------------------------------------------------------------
+ *
+ * numeric.c
+ *	Numeric PostgreSQL type
+ *
+ * $Id*
+ * 
+ *-------------------------------------------------------------------------
+ */
+
+#include "postgres.h"
+
+#include "utils/numeric.h"
+#include "common/int.h"
+
+#include "columnar/vectorization/types/numeric.h"
+#include "columnar/vectorization/types/types.h"
+
+#define NBASE		10000
+#define HALF_NBASE	5000
+#define DEC_DIGITS			4	/* decimal digits per NBASE digit */
+#define MUL_GUARD_DIGITS	2	/* these are measured in NBASE digits */
+#define DIV_GUARD_DIGITS	4
+
+typedef int16 NumericDigit;
+
+/*
+ * The Numeric type as stored on disk.
+ *
+ * If the high bits of the first word of a NumericChoice (n_header, or
+ * n_short.n_header, or n_long.n_sign_dscale) are NUMERIC_SHORT, then the
+ * numeric follows the NumericShort format; if they are NUMERIC_POS or
+ * NUMERIC_NEG, it follows the NumericLong format. If they are NUMERIC_SPECIAL,
+ * the value is a NaN or Infinity.  We currently always store SPECIAL values
+ * using just two bytes (i.e. only n_header), but previous releases used only
+ * the NumericLong format, so we might find 4-byte NaNs (though not infinities)
+ * on disk if a database has been migrated using pg_upgrade.  In either case,
+ * the low-order bits of a special value's header are reserved and currently
+ * should always be set to zero.
+ *
+ * In the NumericShort format, the remaining 14 bits of the header word
+ * (n_short.n_header) are allocated as follows: 1 for sign (positive or
+ * negative), 6 for dynamic scale, and 7 for weight.  In practice, most
+ * commonly-encountered values can be represented this way.
+ *
+ * In the NumericLong format, the remaining 14 bits of the header word
+ * (n_long.n_sign_dscale) represent the display scale; and the weight is
+ * stored separately in n_weight.
+ *
+ * NOTE: by convention, values in the packed form have been stripped of
+ * all leading and trailing zero digits (where a "digit" is of base NBASE).
+ * In particular, if the value is zero, there will be no digits at all!
+ * The weight is arbitrary in that case, but we normally set it to zero.
+ */
+
+struct NumericShort
+{
+	uint16		n_header;		/* Sign + display scale + weight */
+	NumericDigit n_data[FLEXIBLE_ARRAY_MEMBER]; /* Digits */
+};
+
+struct NumericLong
+{
+	uint16		n_sign_dscale;	/* Sign + display scale */
+	int16		n_weight;		/* Weight of 1st digit	*/
+	NumericDigit n_data[FLEXIBLE_ARRAY_MEMBER]; /* Digits */
+};
+
+union NumericChoice
+{
+	uint16		n_header;		/* Header word */
+	struct NumericLong n_long;	/* Long form (4-byte header) */
+	struct NumericShort n_short;	/* Short form (2-byte header) */
+};
+
+struct NumericData
+{
+	int32		vl_len_;		/* varlena header (do not touch directly!) */
+	union NumericChoice choice; /* choice of format */
+};
+
+/*
+ * Interpretation of high bits.
+ */
+
+#define NUMERIC_SIGN_MASK	0xC000
+#define NUMERIC_POS			0x0000
+#define NUMERIC_NEG			0x4000
+#define NUMERIC_SHORT		0x8000
+#define NUMERIC_SPECIAL		0xC000
+
+#define NUMERIC_FLAGBITS(n) ((n)->choice.n_header & NUMERIC_SIGN_MASK)
+#define NUMERIC_IS_SHORT(n)		(NUMERIC_FLAGBITS(n) == NUMERIC_SHORT)
+#define NUMERIC_IS_SPECIAL(n)	(NUMERIC_FLAGBITS(n) == NUMERIC_SPECIAL)
+
+#define NUMERIC_HDRSZ	(VARHDRSZ + sizeof(uint16) + sizeof(int16))
+#define NUMERIC_HDRSZ_SHORT (VARHDRSZ + sizeof(uint16))
+
+/*
+ * If the flag bits are NUMERIC_SHORT or NUMERIC_SPECIAL, we want the short
+ * header; otherwise, we want the long one.  Instead of testing against each
+ * value, we can just look at the high bit, for a slight efficiency gain.
+ */
+#define NUMERIC_HEADER_IS_SHORT(n)	(((n)->choice.n_header & 0x8000) != 0)
+#define NUMERIC_HEADER_SIZE(n) \
+	(VARHDRSZ + sizeof(uint16) + \
+	 (NUMERIC_HEADER_IS_SHORT(n) ? 0 : sizeof(int16)))
+
+/*
+ * Definitions for special values (NaN, positive infinity, negative infinity).
+ *
+ * The two bits after the NUMERIC_SPECIAL bits are 00 for NaN, 01 for positive
+ * infinity, 11 for negative infinity.  (This makes the sign bit match where
+ * it is in a short-format value, though we make no use of that at present.)
+ * We could mask off the remaining bits before testing the active bits, but
+ * currently those bits must be zeroes, so masking would just add cycles.
+ */
+#define NUMERIC_EXT_SIGN_MASK	0xF000	/* high bits plus NaN/Inf flag bits */
+#define NUMERIC_NAN				0xC000
+#define NUMERIC_PINF			0xD000
+#define NUMERIC_NINF			0xF000
+#define NUMERIC_INF_SIGN_MASK	0x2000
+
+#define NUMERIC_EXT_FLAGBITS(n)	((n)->choice.n_header & NUMERIC_EXT_SIGN_MASK)
+#define NUMERIC_IS_NAN(n)		((n)->choice.n_header == NUMERIC_NAN)
+#define NUMERIC_IS_PINF(n)		((n)->choice.n_header == NUMERIC_PINF)
+#define NUMERIC_IS_NINF(n)		((n)->choice.n_header == NUMERIC_NINF)
+#define NUMERIC_IS_INF(n) \
+	(((n)->choice.n_header & ~NUMERIC_INF_SIGN_MASK) == NUMERIC_PINF)
+
+/*
+ * Short format definitions.
+ */
+
+#define NUMERIC_SHORT_SIGN_MASK			0x2000
+#define NUMERIC_SHORT_DSCALE_MASK		0x1F80
+#define NUMERIC_SHORT_DSCALE_SHIFT		7
+#define NUMERIC_SHORT_DSCALE_MAX		\
+	(NUMERIC_SHORT_DSCALE_MASK >> NUMERIC_SHORT_DSCALE_SHIFT)
+#define NUMERIC_SHORT_WEIGHT_SIGN_MASK	0x0040
+#define NUMERIC_SHORT_WEIGHT_MASK		0x003F
+#define NUMERIC_SHORT_WEIGHT_MAX		NUMERIC_SHORT_WEIGHT_MASK
+#define NUMERIC_SHORT_WEIGHT_MIN		(-(NUMERIC_SHORT_WEIGHT_MASK+1))
+
+/*
+ * Extract sign, display scale, weight.  These macros extract field values
+ * suitable for the NumericVar format from the Numeric (on-disk) format.
+ *
+ * Note that we don't trouble to ensure that dscale and weight read as zero
+ * for an infinity; however, that doesn't matter since we never convert
+ * "special" numerics to NumericVar form.  Only the constants defined below
+ * (const_nan, etc) ever represent a non-finite value as a NumericVar.
+ */
+
+#define NUMERIC_DSCALE_MASK			0x3FFF
+#define NUMERIC_DSCALE_MAX			NUMERIC_DSCALE_MASK
+
+#define NUMERIC_SIGN(n) \
+	(NUMERIC_IS_SHORT(n) ? \
+		(((n)->choice.n_short.n_header & NUMERIC_SHORT_SIGN_MASK) ? \
+		 NUMERIC_NEG : NUMERIC_POS) : \
+		(NUMERIC_IS_SPECIAL(n) ? \
+		 NUMERIC_EXT_FLAGBITS(n) : NUMERIC_FLAGBITS(n)))
+#define NUMERIC_DSCALE(n)	(NUMERIC_HEADER_IS_SHORT((n)) ? \
+	((n)->choice.n_short.n_header & NUMERIC_SHORT_DSCALE_MASK) \
+		>> NUMERIC_SHORT_DSCALE_SHIFT \
+	: ((n)->choice.n_long.n_sign_dscale & NUMERIC_DSCALE_MASK))
+
+#define NUMERIC_WEIGHT(n)	(NUMERIC_HEADER_IS_SHORT((n)) ? \
+	(((n)->choice.n_short.n_header & NUMERIC_SHORT_WEIGHT_SIGN_MASK ? \
+		~NUMERIC_SHORT_WEIGHT_MASK : 0) \
+	 | ((n)->choice.n_short.n_header & NUMERIC_SHORT_WEIGHT_MASK)) \
+	: ((n)->choice.n_long.n_weight))
+
+/* ----------
+ * NumericVar is the format we use for arithmetic.  The digit-array part
+ * is the same as the NumericData storage format, but the header is more
+ * complex.
+ *
+ * The value represented by a NumericVar is determined by the sign, weight,
+ * ndigits, and digits[] array.  If it is a "special" value (NaN or Inf)
+ * then only the sign field matters; ndigits should be zero, and the weight
+ * and dscale fields are ignored.
+ *
+ * Note: the first digit of a NumericVar's value is assumed to be multiplied
+ * by NBASE ** weight.  Another way to say it is that there are weight+1
+ * digits before the decimal point.  It is possible to have weight < 0.
+ *
+ * buf points at the physical start of the palloc'd digit buffer for the
+ * NumericVar.  digits points at the first digit in actual use (the one
+ * with the specified weight).  We normally leave an unused digit or two
+ * (preset to zeroes) between buf and digits, so that there is room to store
+ * a carry out of the top digit without reallocating space.  We just need to
+ * decrement digits (and increment weight) to make room for the carry digit.
+ * (There is no such extra space in a numeric value stored in the database,
+ * only in a NumericVar in memory.)
+ *
+ * If buf is NULL then the digit buffer isn't actually palloc'd and should
+ * not be freed --- see the constants below for an example.
+ *
+ * dscale, or display scale, is the nominal precision expressed as number
+ * of digits after the decimal point (it must always be >= 0 at present).
+ * dscale may be more than the number of physically stored fractional digits,
+ * implying that we have suppressed storage of significant trailing zeroes.
+ * It should never be less than the number of stored digits, since that would
+ * imply hiding digits that are present.  NOTE that dscale is always expressed
+ * in *decimal* digits, and so it may correspond to a fractional number of
+ * base-NBASE digits --- divide by DEC_DIGITS to convert to NBASE digits.
+ *
+ * rscale, or result scale, is the target precision for a computation.
+ * Like dscale it is expressed as number of *decimal* digits after the decimal
+ * point, and is always >= 0 at present.
+ * Note that rscale is not stored in variables --- it's figured on-the-fly
+ * from the dscales of the inputs.
+ *
+ * While we consistently use "weight" to refer to the base-NBASE weight of
+ * a numeric value, it is convenient in some scale-related calculations to
+ * make use of the base-10 weight (ie, the approximate log10 of the value).
+ * To avoid confusion, such a decimal-units weight is called a "dweight".
+ *
+ * NB: All the variable-level functions are written in a style that makes it
+ * possible to give one and the same variable as argument and destination.
+ * This is feasible because the digit buffer is separate from the variable.
+ * ----------
+ */
+typedef struct NumericVar
+{
+	int			ndigits;		/* # of digits in digits[] - can be 0! */
+	int			weight;			/* weight of first digit */
+	int			sign;			/* NUMERIC_POS, _NEG, _NAN, _PINF, or _NINF */
+	int			dscale;			/* display scale */
+	NumericDigit *buf;			/* start of palloc'd space for digits[] */
+	NumericDigit *digits;		/* base-NBASE digits */
+} NumericVar;
+
+
+/* ----------
+ * Local functions
+ * ----------
+ */
+
+#define digitbuf_alloc(ndigits)  \
+	((NumericDigit *) palloc((ndigits) * sizeof(NumericDigit)))
+#define digitbuf_free(buf)	\
+	do { \
+		 if ((buf) != NULL) \
+			 pfree(buf); \
+	} while (0)
+
+#define init_var(v) memset(v, 0, sizeof(NumericVar))
+
+#define NUMERIC_DIGITS(num) (NUMERIC_HEADER_IS_SHORT(num) ? \
+	(num)->choice.n_short.n_data : (num)->choice.n_long.n_data)
+#define NUMERIC_NDIGITS(num) \
+	((VARSIZE(num) - NUMERIC_HEADER_SIZE(num)) / sizeof(NumericDigit))
+#define NUMERIC_CAN_BE_SHORT(scale,weight) \
+	((scale) <= NUMERIC_SHORT_DSCALE_MAX && \
+	(weight) <= NUMERIC_SHORT_WEIGHT_MAX && \
+	(weight) >= NUMERIC_SHORT_WEIGHT_MIN)
+
+static void alloc_var(NumericVar *var, int ndigits);
+static void free_var(NumericVar *var);
+static Numeric make_numeric(const struct NumericVar *var);
+
+/*
+ * alloc_var() -
+ *
+ *	Allocate a digit buffer of ndigits digits (plus a spare digit for rounding)
+ */
+static void
+alloc_var(NumericVar *var, int ndigits)
+{
+	digitbuf_free(var->buf);
+	var->buf = digitbuf_alloc(ndigits + 1);
+	var->buf[0] = 0;			/* spare digit for rounding */
+	var->digits = var->buf + 1;
+	var->ndigits = ndigits;
+}
+
+/*
+ * free_var() -
+ *
+ *	Return the digit buffer of a variable to the free pool
+ */
+static void
+free_var(NumericVar *var)
+{
+	digitbuf_free(var->buf);
+	var->buf = NULL;
+	var->digits = NULL;
+	var->sign = NUMERIC_NAN;
+}
+
+/*
+ * Convert 128 bit integer to numeric.
+ */
+static void
+int128_to_numericvar(int128 val, NumericVar *var)
+{
+	uint128		uval,
+				newuval;
+	NumericDigit *ptr;
+	int			ndigits;
+
+	/* int128 can require at most 39 decimal digits; add one for safety */
+	alloc_var(var, 40 / DEC_DIGITS);
+	if (val < 0)
+	{
+		var->sign = NUMERIC_NEG;
+		uval = -val;
+	}
+	else
+	{
+		var->sign = NUMERIC_POS;
+		uval = val;
+	}
+	var->dscale = 0;
+	if (val == 0)
+	{
+		var->ndigits = 0;
+		var->weight = 0;
+		return;
+	}
+	ptr = var->digits + var->ndigits;
+	ndigits = 0;
+	do
+	{
+		ptr--;
+		ndigits++;
+		newuval = uval / NBASE;
+		*ptr = uval - newuval * NBASE;
+		uval = newuval;
+	} while (uval);
+	var->digits = ptr;
+	var->ndigits = ndigits;
+	var->weight = ndigits - 1;
+}
+
+/*
+ *  make_result -
+ *
+ *	Create the packed db numeric format in palloc()'d memory from
+ *	a variable.  This will handle NaN and Infinity cases.
+ *
+ */
+static Numeric
+make_numeric(const struct NumericVar *var)
+{
+	Numeric		result;
+	NumericDigit *digits = var->digits;
+	int			weight = var->weight;
+	int			sign = var->sign;
+	int			n;
+	Size		len;
+
+	if ((sign & NUMERIC_SIGN_MASK) == NUMERIC_SPECIAL)
+	{
+		/*
+		 * Verify valid special value.  This could be just an Assert, perhaps,
+		 * but it seems worthwhile to expend a few cycles to ensure that we
+		 * never write any nonzero reserved bits to disk.
+		 */
+		if (!(sign == NUMERIC_NAN ||
+			  sign == NUMERIC_PINF ||
+			  sign == NUMERIC_NINF))
+			elog(ERROR, "invalid numeric sign value 0x%x", sign);
+
+		result = (Numeric) palloc(NUMERIC_HDRSZ_SHORT);
+
+		SET_VARSIZE(result, NUMERIC_HDRSZ_SHORT);
+		result->choice.n_header = sign;
+		/* the header word is all we need */
+
+		return result;
+	}
+
+	n = var->ndigits;
+
+	/* truncate leading zeroes */
+	while (n > 0 && *digits == 0)
+	{
+		digits++;
+		weight--;
+		n--;
+	}
+	/* truncate trailing zeroes */
+	while (n > 0 && digits[n - 1] == 0)
+		n--;
+
+	/* If zero result, force to weight=0 and positive sign */
+	if (n == 0)
+	{
+		weight = 0;
+		sign = NUMERIC_POS;
+	}
+
+	/* Build the result */
+	if (NUMERIC_CAN_BE_SHORT(var->dscale, weight))
+	{
+		len = NUMERIC_HDRSZ_SHORT + n * sizeof(NumericDigit);
+		result = (Numeric) palloc(len);
+		SET_VARSIZE(result, len);
+		result->choice.n_short.n_header =
+			(sign == NUMERIC_NEG ? (NUMERIC_SHORT | NUMERIC_SHORT_SIGN_MASK)
+			 : NUMERIC_SHORT)
+			| (var->dscale << NUMERIC_SHORT_DSCALE_SHIFT)
+			| (weight < 0 ? NUMERIC_SHORT_WEIGHT_SIGN_MASK : 0)
+			| (weight & NUMERIC_SHORT_WEIGHT_MASK);
+	}
+	else
+	{
+		len = NUMERIC_HDRSZ + n * sizeof(NumericDigit);
+		result = (Numeric) palloc(len);
+		SET_VARSIZE(result, len);
+		result->choice.n_long.n_sign_dscale =
+			sign | (var->dscale & NUMERIC_DSCALE_MASK);
+		result->choice.n_long.n_weight = weight;
+	}
+
+	Assert(NUMERIC_NDIGITS(result) == n);
+	if (n > 0)
+		memcpy(NUMERIC_DIGITS(result), digits, n * sizeof(NumericDigit));
+
+	/* Check for overflow of int16 fields */
+	if (NUMERIC_WEIGHT(result) != weight ||
+		NUMERIC_DSCALE(result) != var->dscale)
+	{
+		ereport(ERROR,
+				(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
+				errmsg("value overflows numeric format")));
+
+	}
+
+	return result;
+}
+
+Numeric int128_to_numeric(int128 val)
+{
+	Numeric		res;
+	NumericVar	result;
+
+	init_var(&result);
+
+	int128_to_numericvar(val, &result);
+
+	res = make_numeric(&result);
+
+	free_var(&result);
+
+	return res;
+}

--- a/columnar/src/include/columnar/columnar.h
+++ b/columnar/src/include/columnar/columnar.h
@@ -17,6 +17,7 @@
 #include "fmgr.h"
 #include "lib/stringinfo.h"
 #include "nodes/parsenodes.h"
+#include "nodes/extensible.h"
 #include "port/atomics.h"
 #include "storage/bufpage.h"
 #include "storage/lockdefs.h"
@@ -260,7 +261,6 @@ extern int columnar_page_cache_size;
 typedef void (*ColumnarTableSetOptions_hook_type)(Oid relid, ColumnarOptions options);
 
 extern void columnar_init(void);
-extern void columnar_init_gucs(void);
 
 extern CompressionType ParseCompressionType(const char *compressionTypeString);
 
@@ -375,6 +375,9 @@ extern bytea * ReadChunkRowMask(RelFileNode relfilenode, Snapshot snapshot,
 								MemoryContext ctx,
 								uint64 stripeFirstRowNumber, int rowCount);
 extern Datum create_table_row_mask(PG_FUNCTION_ARGS);
+
+/* columnar_planner_hook.c */
+extern void columnar_planner_init(void);
 
 /* write_state_interface.c */
 extern void FlushWriteStateWithNewSnapshot(Oid relfilenode,

--- a/columnar/src/include/columnar/columnar_customscan.h
+++ b/columnar/src/include/columnar/columnar_customscan.h
@@ -13,7 +13,12 @@
 #ifndef COLUMNAR_CUSTOMSCAN_H
 #define COLUMNAR_CUSTOMSCAN_H
 
-void columnar_customscan_init(void);
+#include "nodes/extensible.h"
 
+/* Flag to indicate is vectorized aggregate used in execution */
+#define CUSTOM_SCAN_VECTORIZED_AGGREGATE 1
+
+extern void columnar_customscan_init(void);
+extern const CustomScanMethods * columnar_customscan_methods(void);
 
 #endif /* COLUMNAR_CUSTOMSCAN_H */

--- a/columnar/src/include/columnar/utils/listutils.h
+++ b/columnar/src/include/columnar/utils/listutils.h
@@ -16,9 +16,15 @@
 #include "c.h"
 
 #include "nodes/pg_list.h"
-#include "pg_version_compat.h"
+
 #include "utils/array.h"
 #include "utils/hsearch.h"
+#include "nodes/makefuncs.h"
+#include "nodes/nodes.h"
+#include "nodes/nodeFuncs.h"
+#include "nodes/primnodes.h"
+
+#include "pg_version_compat.h"
 
 
 /*
@@ -166,15 +172,32 @@ typedef struct ListCellAndListWrapper
 #define foreach_ptr_append(var, l) foreach_ptr(var, l)
 #endif
 
-/* utility functions declaration shared within this module */
-extern List * SortList(List *pointerList,
-					   int (*ComparisonFunction)(const void *, const void *));
-extern void ** PointerArrayFromList(List *pointerList);
-extern HTAB * ListToHashSet(List *pointerList, Size keySize, bool isStringList);
-extern char * StringJoin(List *stringList, char delimiter);
-extern List * ListTake(List *pointerList, int size);
-extern void * safe_list_nth(const List *list, int index);
-extern List * GeneratePositiveIntSequenceList(int upTo);
-extern List * GenerateListFromElement(void *listElement, int listLength);
+static inline List*
+CustomBuildTargetList(List* tlist, Index varNo)
+{
+	List		*result_tlist = NIL;
+	ListCell	*lc;
+
+	foreach (lc, tlist)
+	{
+		TargetEntry	*tle = (TargetEntry *) lfirst(lc);
+
+		Var *var = makeVar(varNo,
+						   tle->resno,
+						   exprType((Node *) tle->expr),
+						   exprTypmod((Node *) tle->expr),
+						   exprCollation((Node *) tle->expr),
+						   0);
+
+		TargetEntry *newtle = makeTargetEntry((Expr *) var,
+											  tle->resno,
+											  tle->resname,
+											  tle->resjunk);
+
+		result_tlist = lappend(result_tlist, newtle);
+	}
+
+	return result_tlist;
+}
 
 #endif /* CITUS_LISTUTILS_H */

--- a/columnar/src/include/columnar/vectorization/columnar_vector_execution.h
+++ b/columnar/src/include/columnar/vectorization/columnar_vector_execution.h
@@ -16,6 +16,8 @@
 #include "nodes/pg_list.h"
 #include "nodes/primnodes.h"
 
+extern bool CheckOpExprArgumentRules(List *args);
+extern bool GetVectorizedProcedureOid(Oid procedureOid, Oid *vectorizedProcedureOid);
 extern List * CreateVectorizedExprList(List *exprList);
 extern List * ConstructVectorizedQualList(TupleTableSlot *slot, List *vectorizedQual);
 extern bool * ExecuteVectorizedQual(TupleTableSlot *slot,

--- a/columnar/src/include/columnar/vectorization/columnar_vector_types.h
+++ b/columnar/src/include/columnar/vectorization/columnar_vector_types.h
@@ -28,8 +28,8 @@ typedef struct VectorTupleTableSlot
 	TupleTableSlot tts;
 	/* How many tuples does this slot contain */ 
 	uint32 dimension;
-	/* Skip array to represent filtered tuples */
-	bool skip[COLUMNAR_VECTOR_COLUMN_SIZE];
+	/* Keep array to represent filtered tuples */
+	bool keep[COLUMNAR_VECTOR_COLUMN_SIZE];
 	/* Row Number */
 	uint64 rowNumber[COLUMNAR_VECTOR_COLUMN_SIZE];
 } VectorTupleTableSlot;
@@ -50,10 +50,14 @@ extern VectorColumn * BuildVectorColumn(int16 columnDimension,
 										int16 columnTypeLen,
 										bool columnIsVal,
 										uint64 *rowNumber);
-extern void extractTupleFromVectorSlot(TupleTableSlot *out, 
+extern void ExtractTupleFromVectorSlot(TupleTableSlot *out, 
 									   VectorTupleTableSlot *vectorSlot, 
 									   int32 index,
-									   Bitmapset *attrNeeded);
+									   List *attrNeededList);
+extern void WriteTupleToVectorSlot(TupleTableSlot *in,
+								   VectorTupleTableSlot *vectorSlot,
+								   int32 index);
+extern void CleanupVectorSlot(VectorTupleTableSlot *vectorSlot);
 
 typedef enum VectorQualType
 {

--- a/columnar/src/include/columnar/vectorization/nodes/columnar_aggregator_node.h
+++ b/columnar/src/include/columnar/vectorization/nodes/columnar_aggregator_node.h
@@ -1,0 +1,29 @@
+/*-------------------------------------------------------------------------
+ *
+ * columnar_aggregator_node.h
+ *	Custom scan method for aggregation
+ * 
+ * IDENTIFICATION
+ *	src/backend/columnar/vectorization/nodes/columnar_aggregator_node.c
+ *
+ *-------------------------------------------------------------------------
+ */
+
+
+#ifndef COLUMNAR_AGGEREGATOR_NODE_H
+#define COLUMNAR_AGGEREGATOR_NODE_H
+
+#include "postgres.h"
+
+#include "nodes/execnodes.h"
+
+typedef struct VectorAggState
+{
+	CustomScanState css;
+	AggState *aggstate;
+} VectorAggState;
+
+extern CustomScan *columnar_create_aggregator_node(void);
+extern void columnar_register_aggregator_node(void);
+
+#endif

--- a/columnar/src/include/columnar/vectorization/types/numeric.h
+++ b/columnar/src/include/columnar/vectorization/types/numeric.h
@@ -1,0 +1,19 @@
+/*-------------------------------------------------------------------------
+ *
+ * numeric.h
+ * 
+ * IDENTIFICATION
+ *	src/backend/columnar/vectorization/types/numeric.c
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#ifndef VECTORIZATION_TYPE_INT128_H
+#define VECTORIZATION_TYPE_INT128_H
+
+#include "postgres.h"
+
+#include "utils/numeric.h"
+extern Numeric int128_to_numeric(int128 val);
+
+#endif

--- a/columnar/src/include/columnar/vectorization/types/types.h
+++ b/columnar/src/include/columnar/vectorization/types/types.h
@@ -85,5 +85,20 @@ Datum v##FNAME##OPSTR(PG_FUNCTION_ARGS) 									\
 	_BUILD_CMP_OP_INT(FNAME, LTYPE, RTYPE, <=, le)		\
 	_BUILD_CMP_OP_INT(FNAME, LTYPE, RTYPE, >=, ge)		\
 
+
+typedef struct Int128AggState
+{
+	bool		calcSumX2;		/* if true, calculate sumX2 */
+	int64		N;				/* count of processed numbers */
+	int128		sumX;			/* sum of processed numbers */
+	int128		sumX2;			/* sum of squares of processed numbers */
+} Int128AggState;
+
+typedef struct Int64AggState
+{
+	int64		N;				/* count of processed numbers */
+	int64		sumX;			/* sum of processed numbers */
+} Int64AggState;
+
 #endif
 

--- a/columnar/src/test/regress/columnar_schedule
+++ b/columnar/src/test/regress/columnar_schedule
@@ -34,3 +34,4 @@ test: columnar_matview
 #test: columnar_memory
 test: columnar_alter_table_set_access_method
 test: columnar_cache
+test: columnar_aggregates

--- a/columnar/src/test/regress/expected/columnar_aggregates.out
+++ b/columnar/src/test/regress/expected/columnar_aggregates.out
@@ -1,0 +1,241 @@
+-- Custom direct aggregates implementation 
+-- 1. SMALLINT
+CREATE TABLE t_smallint(a SMALLINT) USING columnar;
+INSERT INTO t_smallint SELECT g % 16384 FROM GENERATE_SERIES(0, 3000000) g;
+EXPLAIN (verbose, costs off, timing off, summary off) SELECT COUNT(*), SUM(a), AVG(a), MIN(a), MAX(a) FROM t_smallint;
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: vcount(*), vsum(a), vavg(a), vmin(a), vmax(a)
+   ->  Gather
+         Output: (PARTIAL vcount(*)), (PARTIAL vsum(a)), (PARTIAL vavg(a)), (PARTIAL vmin(a)), (PARTIAL vmax(a))
+         Workers Planned: 7
+         ->  Parallel Custom Scan (VectorAggNode)
+               Output: (PARTIAL vcount(*)), (PARTIAL vsum(a)), (PARTIAL vavg(a)), (PARTIAL vmin(a)), (PARTIAL vmax(a))
+               ->  Parallel Custom Scan (ColumnarScan) on public.t_smallint
+                     Output: a
+                     Columnar Projected Columns: a
+(10 rows)
+
+SELECT SUM(a), AVG(a), MIN(a), MAX(a) FROM t_smallint;
+     sum     |          avg          | min |  max  
+-------------+-----------------------+-----+-------
+ 24561838944 | 8187.2769189076936974 |   0 | 16383
+(1 row)
+
+SET columnar.enable_vectorization TO false;
+EXPLAIN (verbose, costs off, timing off, summary off) SELECT COUNT(*), SUM(a), AVG(a), MIN(a), MAX(a) FROM t_smallint;
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: count(*), sum(a), avg(a), min(a), max(a)
+   ->  Gather
+         Output: (PARTIAL count(*)), (PARTIAL sum(a)), (PARTIAL avg(a)), (PARTIAL min(a)), (PARTIAL max(a))
+         Workers Planned: 7
+         ->  Partial Aggregate
+               Output: PARTIAL count(*), PARTIAL sum(a), PARTIAL avg(a), PARTIAL min(a), PARTIAL max(a)
+               ->  Parallel Custom Scan (ColumnarScan) on public.t_smallint
+                     Output: a
+                     Columnar Projected Columns: a
+(10 rows)
+
+SELECT SUM(a), AVG(a), MIN(a), MAX(a) FROM t_smallint;
+     sum     |          avg          | min |  max  
+-------------+-----------------------+-----+-------
+ 24561838944 | 8187.2769189076936974 |   0 | 16383
+(1 row)
+
+SET columnar.enable_vectorization TO default;
+DROP TABLE t_smallint;
+-- 2. INT
+CREATE TABLE t_int(a INT) USING columnar;
+INSERT INTO t_int SELECT g FROM GENERATE_SERIES(0, 3000000) g;
+EXPLAIN (verbose, costs off, timing off, summary off) SELECT SUM(a), AVG(a), MIN(a), MAX(a) FROM t_int;
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: vsum(a), vavg(a), vmin(a), vmax(a)
+   ->  Gather
+         Output: (PARTIAL vsum(a)), (PARTIAL vavg(a)), (PARTIAL vmin(a)), (PARTIAL vmax(a))
+         Workers Planned: 7
+         ->  Parallel Custom Scan (VectorAggNode)
+               Output: (PARTIAL vsum(a)), (PARTIAL vavg(a)), (PARTIAL vmin(a)), (PARTIAL vmax(a))
+               ->  Parallel Custom Scan (ColumnarScan) on public.t_int
+                     Output: a
+                     Columnar Projected Columns: a
+(10 rows)
+
+SELECT SUM(a), AVG(a), MIN(a), MAX(a) FROM t_int;
+      sum      |         avg          | min |   max   
+---------------+----------------------+-----+---------
+ 4500001500000 | 1500000.000000000000 |   0 | 3000000
+(1 row)
+
+SET columnar.enable_vectorization TO false;
+EXPLAIN (verbose, costs off, timing off, summary off) SELECT SUM(a), AVG(a), MIN(a), MAX(a) FROM t_int;
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: sum(a), avg(a), min(a), max(a)
+   ->  Gather
+         Output: (PARTIAL sum(a)), (PARTIAL avg(a)), (PARTIAL min(a)), (PARTIAL max(a))
+         Workers Planned: 7
+         ->  Partial Aggregate
+               Output: PARTIAL sum(a), PARTIAL avg(a), PARTIAL min(a), PARTIAL max(a)
+               ->  Parallel Custom Scan (ColumnarScan) on public.t_int
+                     Output: a
+                     Columnar Projected Columns: a
+(10 rows)
+
+SELECT SUM(a), AVG(a), MIN(a), MAX(a) FROM t_int;
+      sum      |         avg          | min |   max   
+---------------+----------------------+-----+---------
+ 4500001500000 | 1500000.000000000000 |   0 | 3000000
+(1 row)
+
+SET columnar.enable_vectorization TO default;
+DROP TABLE t_int;
+-- 3. BIGINT
+CREATE TABLE t_bigint(a BIGINT) USING columnar;
+INSERT INTO t_bigint SELECT g FROM GENERATE_SERIES(0, 3000000) g;
+EXPLAIN (verbose, costs off, timing off, summary off) SELECT SUM(a), AVG(a), MIN(a), MAX(a) FROM t_bigint;
+                                            QUERY PLAN                                            
+--------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: vsum(a), vavg(a), vmin(a), vmax(a)
+   ->  Gather
+         Output: (PARTIAL vsum(a)), (PARTIAL vavg(a)), (PARTIAL vmin(a)), (PARTIAL vmax(a))
+         Workers Planned: 7
+         ->  Parallel Custom Scan (VectorAggNode)
+               Output: (PARTIAL vsum(a)), (PARTIAL vavg(a)), (PARTIAL vmin(a)), (PARTIAL vmax(a))
+               ->  Parallel Custom Scan (ColumnarScan) on public.t_bigint
+                     Output: a
+                     Columnar Projected Columns: a
+(10 rows)
+
+SELECT SUM(a), AVG(a), MIN(a), MAX(a) FROM t_bigint;
+      sum      |         avg          | min |   max   
+---------------+----------------------+-----+---------
+ 4500001500000 | 1500000.000000000000 |   0 | 3000000
+(1 row)
+
+SET columnar.enable_vectorization TO false;
+EXPLAIN (verbose, costs off, timing off, summary off) SELECT SUM(a), AVG(a), MIN(a), MAX(a) FROM t_bigint;
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: sum(a), avg(a), min(a), max(a)
+   ->  Gather
+         Output: (PARTIAL sum(a)), (PARTIAL avg(a)), (PARTIAL min(a)), (PARTIAL max(a))
+         Workers Planned: 7
+         ->  Partial Aggregate
+               Output: PARTIAL sum(a), PARTIAL avg(a), PARTIAL min(a), PARTIAL max(a)
+               ->  Parallel Custom Scan (ColumnarScan) on public.t_bigint
+                     Output: a
+                     Columnar Projected Columns: a
+(10 rows)
+
+SELECT SUM(a), AVG(a), MIN(a), MAX(a) FROM t_bigint;
+      sum      |         avg          | min |   max   
+---------------+----------------------+-----+---------
+ 4500001500000 | 1500000.000000000000 |   0 | 3000000
+(1 row)
+
+SET columnar.enable_vectorization TO default;
+DROP TABLE t_bigint;
+-- 4. DATE
+CREATE TABLE t_date(a DATE) USING columnar;
+INSERT INTO t_date VALUES ('2000-01-01'), ('2020-01-01'), ('2010-01-01'), ('2000-01-02');
+EXPLAIN (verbose, costs off, timing off, summary off) SELECT MIN(a), MAX(a) FROM t_date;
+                    QUERY PLAN                     
+---------------------------------------------------
+ Custom Scan (VectorAggNode)
+   Output: (vmin(a)), (vmax(a))
+   ->  Custom Scan (ColumnarScan) on public.t_date
+         Output: a
+         Columnar Projected Columns: a
+(5 rows)
+
+SELECT MIN(a), MAX(a) FROM t_date;
+    min     |    max     
+------------+------------
+ 01-01-2000 | 01-01-2020
+(1 row)
+
+SET columnar.enable_vectorization TO false;
+EXPLAIN (verbose, costs off, timing off, summary off) SELECT MIN(a), MAX(a) FROM t_date;
+                    QUERY PLAN                     
+---------------------------------------------------
+ Aggregate
+   Output: min(a), max(a)
+   ->  Custom Scan (ColumnarScan) on public.t_date
+         Output: a
+         Columnar Projected Columns: a
+(5 rows)
+
+SELECT MIN(a), MAX(a) FROM t_date;
+    min     |    max     
+------------+------------
+ 01-01-2000 | 01-01-2020
+(1 row)
+
+SET columnar.enable_vectorization TO default;
+DROP TABLE t_date;
+-- Test exception when we fallback to PG aggregator node
+SET client_min_messages TO 'DEBUG1';
+CREATE TABLE t_mixed(a INT, b BIGINT, c DATE, d TIME) using columnar;
+INSERT INTO t_mixed VALUES (0, 1000, '2000-01-01', '23:50'), (10, 2000, '2010-01-01', '00:50');
+DEBUG:  Flushing Stripe of size 2
+-- Vectorized aggregate not found (TIME aggregates are not implemented)
+EXPLAIN (verbose, costs off, timing off, summary off) SELECT MIN(d) FROM t_mixed;
+DEBUG:  Query can't be vectorized. Falling back to original execution.
+DETAIL:  Vectorized aggregate not found.
+                     QUERY PLAN                     
+----------------------------------------------------
+ Aggregate
+   Output: min(d)
+   ->  Custom Scan (ColumnarScan) on public.t_mixed
+         Output: d
+         Columnar Projected Columns: d
+(5 rows)
+
+--Unsupported aggregate argument combination.
+EXPLAIN (verbose, costs off, timing off, summary off) SELECT SUM(a + b) FROM t_mixed;
+DEBUG:  Query can't be vectorized. Falling back to original execution.
+DETAIL:  Unsupported aggregate argument combination.
+                     QUERY PLAN                     
+----------------------------------------------------
+ Aggregate
+   Output: sum((a + b))
+   ->  Custom Scan (ColumnarScan) on public.t_mixed
+         Output: a, b
+         Columnar Projected Columns: a, b
+(5 rows)
+
+-- Vectorized Aggregates accepts only non-const values.
+EXPLAIN (verbose, costs off, timing off, summary off) SELECT COUNT(1) FROM t_mixed;
+DEBUG:  Query can't be vectorized. Falling back to original execution.
+DETAIL:  Vectorized Aggregates accepts only non-const values.
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
+ Aggregate
+   Output: count(1)
+   ->  Custom Scan (ColumnarScan) on public.t_mixed
+         Columnar Projected Columns: <columnar optimized out all columns>
+(4 rows)
+
+-- Vectorized aggregate with DISTINCT not supported.
+EXPLAIN (verbose, costs off, timing off, summary off) SELECT COUNT(DISTINCT a) FROM t_mixed;
+DEBUG:  Query can't be vectorized. Falling back to original execution.
+DETAIL:  Vectorized aggregate with DISTINCT not supported.
+                     QUERY PLAN                     
+----------------------------------------------------
+ Aggregate
+   Output: count(DISTINCT a)
+   ->  Custom Scan (ColumnarScan) on public.t_mixed
+         Output: a
+         Columnar Projected Columns: a
+(5 rows)
+
+DROP TABLE t_mixed;
+SET client_min_messages TO default;

--- a/columnar/src/test/regress/expected/columnar_aggregates_1.out
+++ b/columnar/src/test/regress/expected/columnar_aggregates_1.out
@@ -1,0 +1,233 @@
+-- Custom direct aggregates implementation 
+-- 1. SMALLINT
+CREATE TABLE t_smallint(a SMALLINT) USING columnar;
+INSERT INTO t_smallint SELECT g % 16384 FROM GENERATE_SERIES(0, 3000000) g;
+EXPLAIN (verbose, costs off, timing off, summary off) SELECT COUNT(*), SUM(a), AVG(a), MIN(a), MAX(a) FROM t_smallint;
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: count(*), sum(a), avg(a), min(a), max(a)
+   ->  Gather
+         Output: (PARTIAL count(*)), (PARTIAL sum(a)), (PARTIAL avg(a)), (PARTIAL min(a)), (PARTIAL max(a))
+         Workers Planned: 7
+         ->  Partial Aggregate
+               Output: PARTIAL count(*), PARTIAL sum(a), PARTIAL avg(a), PARTIAL min(a), PARTIAL max(a)
+               ->  Parallel Custom Scan (ColumnarScan) on public.t_smallint
+                     Output: a
+                     Columnar Projected Columns: a
+(10 rows)
+
+SELECT SUM(a), AVG(a), MIN(a), MAX(a) FROM t_smallint;
+     sum     |          avg          | min |  max  
+-------------+-----------------------+-----+-------
+ 24561838944 | 8187.2769189076936974 |   0 | 16383
+(1 row)
+
+SET columnar.enable_vectorization TO false;
+EXPLAIN (verbose, costs off, timing off, summary off) SELECT COUNT(*), SUM(a), AVG(a), MIN(a), MAX(a) FROM t_smallint;
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: count(*), sum(a), avg(a), min(a), max(a)
+   ->  Gather
+         Output: (PARTIAL count(*)), (PARTIAL sum(a)), (PARTIAL avg(a)), (PARTIAL min(a)), (PARTIAL max(a))
+         Workers Planned: 7
+         ->  Partial Aggregate
+               Output: PARTIAL count(*), PARTIAL sum(a), PARTIAL avg(a), PARTIAL min(a), PARTIAL max(a)
+               ->  Parallel Custom Scan (ColumnarScan) on public.t_smallint
+                     Output: a
+                     Columnar Projected Columns: a
+(10 rows)
+
+SELECT SUM(a), AVG(a), MIN(a), MAX(a) FROM t_smallint;
+     sum     |          avg          | min |  max  
+-------------+-----------------------+-----+-------
+ 24561838944 | 8187.2769189076936974 |   0 | 16383
+(1 row)
+
+SET columnar.enable_vectorization TO default;
+DROP TABLE t_smallint;
+-- 2. INT
+CREATE TABLE t_int(a INT) USING columnar;
+INSERT INTO t_int SELECT g FROM GENERATE_SERIES(0, 3000000) g;
+EXPLAIN (verbose, costs off, timing off, summary off) SELECT SUM(a), AVG(a), MIN(a), MAX(a) FROM t_int;
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: sum(a), avg(a), min(a), max(a)
+   ->  Gather
+         Output: (PARTIAL sum(a)), (PARTIAL avg(a)), (PARTIAL min(a)), (PARTIAL max(a))
+         Workers Planned: 7
+         ->  Partial Aggregate
+               Output: PARTIAL sum(a), PARTIAL avg(a), PARTIAL min(a), PARTIAL max(a)
+               ->  Parallel Custom Scan (ColumnarScan) on public.t_int
+                     Output: a
+                     Columnar Projected Columns: a
+(10 rows)
+
+SELECT SUM(a), AVG(a), MIN(a), MAX(a) FROM t_int;
+      sum      |         avg          | min |   max   
+---------------+----------------------+-----+---------
+ 4500001500000 | 1500000.000000000000 |   0 | 3000000
+(1 row)
+
+SET columnar.enable_vectorization TO false;
+EXPLAIN (verbose, costs off, timing off, summary off) SELECT SUM(a), AVG(a), MIN(a), MAX(a) FROM t_int;
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: sum(a), avg(a), min(a), max(a)
+   ->  Gather
+         Output: (PARTIAL sum(a)), (PARTIAL avg(a)), (PARTIAL min(a)), (PARTIAL max(a))
+         Workers Planned: 7
+         ->  Partial Aggregate
+               Output: PARTIAL sum(a), PARTIAL avg(a), PARTIAL min(a), PARTIAL max(a)
+               ->  Parallel Custom Scan (ColumnarScan) on public.t_int
+                     Output: a
+                     Columnar Projected Columns: a
+(10 rows)
+
+SELECT SUM(a), AVG(a), MIN(a), MAX(a) FROM t_int;
+      sum      |         avg          | min |   max   
+---------------+----------------------+-----+---------
+ 4500001500000 | 1500000.000000000000 |   0 | 3000000
+(1 row)
+
+SET columnar.enable_vectorization TO default;
+DROP TABLE t_int;
+-- 3. BIGINT
+CREATE TABLE t_bigint(a BIGINT) USING columnar;
+INSERT INTO t_bigint SELECT g FROM GENERATE_SERIES(0, 3000000) g;
+EXPLAIN (verbose, costs off, timing off, summary off) SELECT SUM(a), AVG(a), MIN(a), MAX(a) FROM t_bigint;
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: sum(a), avg(a), min(a), max(a)
+   ->  Gather
+         Output: (PARTIAL sum(a)), (PARTIAL avg(a)), (PARTIAL min(a)), (PARTIAL max(a))
+         Workers Planned: 7
+         ->  Partial Aggregate
+               Output: PARTIAL sum(a), PARTIAL avg(a), PARTIAL min(a), PARTIAL max(a)
+               ->  Parallel Custom Scan (ColumnarScan) on public.t_bigint
+                     Output: a
+                     Columnar Projected Columns: a
+(10 rows)
+
+SELECT SUM(a), AVG(a), MIN(a), MAX(a) FROM t_bigint;
+      sum      |         avg          | min |   max   
+---------------+----------------------+-----+---------
+ 4500001500000 | 1500000.000000000000 |   0 | 3000000
+(1 row)
+
+SET columnar.enable_vectorization TO false;
+EXPLAIN (verbose, costs off, timing off, summary off) SELECT SUM(a), AVG(a), MIN(a), MAX(a) FROM t_bigint;
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Finalize Aggregate
+   Output: sum(a), avg(a), min(a), max(a)
+   ->  Gather
+         Output: (PARTIAL sum(a)), (PARTIAL avg(a)), (PARTIAL min(a)), (PARTIAL max(a))
+         Workers Planned: 7
+         ->  Partial Aggregate
+               Output: PARTIAL sum(a), PARTIAL avg(a), PARTIAL min(a), PARTIAL max(a)
+               ->  Parallel Custom Scan (ColumnarScan) on public.t_bigint
+                     Output: a
+                     Columnar Projected Columns: a
+(10 rows)
+
+SELECT SUM(a), AVG(a), MIN(a), MAX(a) FROM t_bigint;
+      sum      |         avg          | min |   max   
+---------------+----------------------+-----+---------
+ 4500001500000 | 1500000.000000000000 |   0 | 3000000
+(1 row)
+
+SET columnar.enable_vectorization TO default;
+DROP TABLE t_bigint;
+-- 4. DATE
+CREATE TABLE t_date(a DATE) USING columnar;
+INSERT INTO t_date VALUES ('2000-01-01'), ('2020-01-01'), ('2010-01-01'), ('2000-01-02');
+EXPLAIN (verbose, costs off, timing off, summary off) SELECT MIN(a), MAX(a) FROM t_date;
+                    QUERY PLAN                     
+---------------------------------------------------
+ Aggregate
+   Output: min(a), max(a)
+   ->  Custom Scan (ColumnarScan) on public.t_date
+         Output: a
+         Columnar Projected Columns: a
+(5 rows)
+
+SELECT MIN(a), MAX(a) FROM t_date;
+    min     |    max     
+------------+------------
+ 01-01-2000 | 01-01-2020
+(1 row)
+
+SET columnar.enable_vectorization TO false;
+EXPLAIN (verbose, costs off, timing off, summary off) SELECT MIN(a), MAX(a) FROM t_date;
+                    QUERY PLAN                     
+---------------------------------------------------
+ Aggregate
+   Output: min(a), max(a)
+   ->  Custom Scan (ColumnarScan) on public.t_date
+         Output: a
+         Columnar Projected Columns: a
+(5 rows)
+
+SELECT MIN(a), MAX(a) FROM t_date;
+    min     |    max     
+------------+------------
+ 01-01-2000 | 01-01-2020
+(1 row)
+
+SET columnar.enable_vectorization TO default;
+DROP TABLE t_date;
+-- Test exception when we fallback to PG aggregator node
+SET client_min_messages TO 'DEBUG1';
+CREATE TABLE t_mixed(a INT, b BIGINT, c DATE, d TIME) using columnar;
+INSERT INTO t_mixed VALUES (0, 1000, '2000-01-01', '23:50'), (10, 2000, '2010-01-01', '00:50');
+DEBUG:  Flushing Stripe of size 2
+-- Vectorized aggregate not found (TIME aggregates are not implemented)
+EXPLAIN (verbose, costs off, timing off, summary off) SELECT MIN(d) FROM t_mixed;
+                     QUERY PLAN                     
+----------------------------------------------------
+ Aggregate
+   Output: min(d)
+   ->  Custom Scan (ColumnarScan) on public.t_mixed
+         Output: d
+         Columnar Projected Columns: d
+(5 rows)
+
+--Unsupported aggregate argument combination.
+EXPLAIN (verbose, costs off, timing off, summary off) SELECT SUM(a + b) FROM t_mixed;
+                     QUERY PLAN                     
+----------------------------------------------------
+ Aggregate
+   Output: sum((a + b))
+   ->  Custom Scan (ColumnarScan) on public.t_mixed
+         Output: a, b
+         Columnar Projected Columns: a, b
+(5 rows)
+
+-- Vectorized Aggregates accepts only non-const values.
+EXPLAIN (verbose, costs off, timing off, summary off) SELECT COUNT(1) FROM t_mixed;
+                                QUERY PLAN                                
+--------------------------------------------------------------------------
+ Aggregate
+   Output: count(1)
+   ->  Custom Scan (ColumnarScan) on public.t_mixed
+         Columnar Projected Columns: <columnar optimized out all columns>
+(4 rows)
+
+-- Vectorized aggregate with DISTINCT not supported.
+EXPLAIN (verbose, costs off, timing off, summary off) SELECT COUNT(DISTINCT a) FROM t_mixed;
+                     QUERY PLAN                     
+----------------------------------------------------
+ Aggregate
+   Output: count(DISTINCT a)
+   ->  Custom Scan (ColumnarScan) on public.t_mixed
+         Output: a
+         Columnar Projected Columns: a
+(5 rows)
+
+DROP TABLE t_mixed;
+SET client_min_messages TO default;

--- a/columnar/src/test/regress/expected/columnar_cache_1.out
+++ b/columnar/src/test/regress/expected/columnar_cache_1.out
@@ -3130,7 +3130,7 @@ EXPLAIN SELECT COUNT(*) FROM t1;
  Finalize Aggregate  (cost=1472.17..1472.18 rows=1 width=8)
    ->  Gather  (cost=1471.54..1472.15 rows=6 width=8)
          Workers Planned: 6
-         ->  Parallel Custom Scan (VectorAggNode)  (cost=471.54..471.55 rows=1 width=8)
+         ->  Partial Aggregate  (cost=471.54..471.55 rows=1 width=8)
                ->  Parallel Custom Scan (ColumnarScan) on t1  (cost=0.00..54.88 rows=166667 width=0)
                      Columnar Projected Columns: <columnar optimized out all columns>
 (6 rows)

--- a/columnar/src/test/regress/sql/columnar_aggregates.sql
+++ b/columnar/src/test/regress/sql/columnar_aggregates.sql
@@ -1,0 +1,109 @@
+-- Custom direct aggregates implementation 
+
+-- 1. SMALLINT
+
+CREATE TABLE t_smallint(a SMALLINT) USING columnar;
+
+INSERT INTO t_smallint SELECT g % 16384 FROM GENERATE_SERIES(0, 3000000) g;
+
+EXPLAIN (verbose, costs off, timing off, summary off) SELECT COUNT(*), SUM(a), AVG(a), MIN(a), MAX(a) FROM t_smallint;
+
+SELECT SUM(a), AVG(a), MIN(a), MAX(a) FROM t_smallint;
+
+SET columnar.enable_vectorization TO false;
+
+EXPLAIN (verbose, costs off, timing off, summary off) SELECT COUNT(*), SUM(a), AVG(a), MIN(a), MAX(a) FROM t_smallint;
+
+SELECT SUM(a), AVG(a), MIN(a), MAX(a) FROM t_smallint;
+
+SET columnar.enable_vectorization TO default;
+
+DROP TABLE t_smallint;
+
+-- 2. INT
+
+CREATE TABLE t_int(a INT) USING columnar;
+
+INSERT INTO t_int SELECT g FROM GENERATE_SERIES(0, 3000000) g;
+
+EXPLAIN (verbose, costs off, timing off, summary off) SELECT SUM(a), AVG(a), MIN(a), MAX(a) FROM t_int;
+
+SELECT SUM(a), AVG(a), MIN(a), MAX(a) FROM t_int;
+
+SET columnar.enable_vectorization TO false;
+
+EXPLAIN (verbose, costs off, timing off, summary off) SELECT SUM(a), AVG(a), MIN(a), MAX(a) FROM t_int;
+
+SELECT SUM(a), AVG(a), MIN(a), MAX(a) FROM t_int;
+
+SET columnar.enable_vectorization TO default;
+
+DROP TABLE t_int;
+
+-- 3. BIGINT
+
+CREATE TABLE t_bigint(a BIGINT) USING columnar;
+
+INSERT INTO t_bigint SELECT g FROM GENERATE_SERIES(0, 3000000) g;
+
+EXPLAIN (verbose, costs off, timing off, summary off) SELECT SUM(a), AVG(a), MIN(a), MAX(a) FROM t_bigint;
+
+SELECT SUM(a), AVG(a), MIN(a), MAX(a) FROM t_bigint;
+
+SET columnar.enable_vectorization TO false;
+
+EXPLAIN (verbose, costs off, timing off, summary off) SELECT SUM(a), AVG(a), MIN(a), MAX(a) FROM t_bigint;
+
+SELECT SUM(a), AVG(a), MIN(a), MAX(a) FROM t_bigint;
+
+SET columnar.enable_vectorization TO default;
+
+DROP TABLE t_bigint;
+
+-- 4. DATE
+
+CREATE TABLE t_date(a DATE) USING columnar;
+
+INSERT INTO t_date VALUES ('2000-01-01'), ('2020-01-01'), ('2010-01-01'), ('2000-01-02');
+
+EXPLAIN (verbose, costs off, timing off, summary off) SELECT MIN(a), MAX(a) FROM t_date;
+
+SELECT MIN(a), MAX(a) FROM t_date;
+
+SET columnar.enable_vectorization TO false;
+
+EXPLAIN (verbose, costs off, timing off, summary off) SELECT MIN(a), MAX(a) FROM t_date;
+
+SELECT MIN(a), MAX(a) FROM t_date;
+
+SET columnar.enable_vectorization TO default;
+
+DROP TABLE t_date;
+
+-- Test exception when we fallback to PG aggregator node
+
+SET client_min_messages TO 'DEBUG1';
+
+CREATE TABLE t_mixed(a INT, b BIGINT, c DATE, d TIME) using columnar;
+
+INSERT INTO t_mixed VALUES (0, 1000, '2000-01-01', '23:50'), (10, 2000, '2010-01-01', '00:50');
+
+-- Vectorized aggregate not found (TIME aggregates are not implemented)
+
+EXPLAIN (verbose, costs off, timing off, summary off) SELECT MIN(d) FROM t_mixed;
+
+--Unsupported aggregate argument combination.
+
+EXPLAIN (verbose, costs off, timing off, summary off) SELECT SUM(a + b) FROM t_mixed;
+
+-- Vectorized Aggregates accepts only non-const values.
+
+EXPLAIN (verbose, costs off, timing off, summary off) SELECT COUNT(1) FROM t_mixed;
+
+-- Vectorized aggregate with DISTINCT not supported.
+
+EXPLAIN (verbose, costs off, timing off, summary off) SELECT COUNT(DISTINCT a) FROM t_mixed;
+
+DROP TABLE t_mixed;
+
+SET client_min_messages TO default;


### PR DESCRIPTION
Handle vacuum process with only one full stripe

* If there is only one stripe that is populated with maximum number of rows do nothing.

Vector read should count only non deleted rows

* When reading next vector for processing we should count only rows that are not deleted.

Vectorized direct aggregates

* Supported version 14/15
* Reused nodeAgg.c to handle vectorized aggregates
* Implementation of aggregate function to handle vector input

Add O3 optimization

* Uses O3 optimization. Flag will be used when `COLUMNAR_O3` is set.