### PR TITLE
[columnar] Direct aggregates should accept only column argument

### DIFF
--- a/columnar/src/backend/columnar/columnar_planner_hook.c
+++ b/columnar/src/backend/columnar/columnar_planner_hook.c
@@ -105,10 +105,10 @@ AggRefArgsExpressionMutator(Node *node, void *context)
 		return (Node *) opExprNode;
 	}
 
-	/* This should handle aggregates that use only const as argument */
-	if (previousNode != NULL && IsA(previousNode, TargetEntry) && IsA(node, Const))
+	/* This should handle aggregates that have non var(column) as argument*/
+	if (previousNode != NULL && IsA(previousNode, TargetEntry) && !IsA(node, Var))
 	{
-		elog(ERROR, "Vectorized Aggregates accepts only non-const values.");
+		elog(ERROR, "Vectorized Aggregates accepts accepts only valid column argument");
 		return false;
 	}
 

--- a/columnar/src/test/regress/expected/columnar_aggregates.out
+++ b/columnar/src/test/regress/expected/columnar_aggregates.out
@@ -199,7 +199,7 @@ DETAIL:  Vectorized aggregate not found.
          Columnar Projected Columns: d
 (5 rows)
 
---Unsupported aggregate argument combination.
+-- Unsupported aggregate argument combination.
 EXPLAIN (verbose, costs off, timing off, summary off) SELECT SUM(a + b) FROM t_mixed;
 DEBUG:  Query can't be vectorized. Falling back to original execution.
 DETAIL:  Unsupported aggregate argument combination.
@@ -215,7 +215,7 @@ DETAIL:  Unsupported aggregate argument combination.
 -- Vectorized Aggregates accepts only non-const values.
 EXPLAIN (verbose, costs off, timing off, summary off) SELECT COUNT(1) FROM t_mixed;
 DEBUG:  Query can't be vectorized. Falling back to original execution.
-DETAIL:  Vectorized Aggregates accepts only non-const values.
+DETAIL:  Vectorized Aggregates accepts accepts only valid column argument
                                 QUERY PLAN                                
 --------------------------------------------------------------------------
  Aggregate
@@ -235,6 +235,20 @@ DETAIL:  Vectorized aggregate with DISTINCT not supported.
    ->  Custom Scan (ColumnarScan) on public.t_mixed
          Output: a
          Columnar Projected Columns: a
+(5 rows)
+
+-- github#145
+-- Vectorized aggregate doesn't accept function as argument
+EXPLAIN (verbose, costs off, timing off, summary off) SELECT SUM(length(b::text)) FROM t_mixed;
+DEBUG:  Query can't be vectorized. Falling back to original execution.
+DETAIL:  Vectorized Aggregates accepts accepts only valid column argument
+                     QUERY PLAN                     
+----------------------------------------------------
+ Aggregate
+   Output: sum(length((b)::text))
+   ->  Custom Scan (ColumnarScan) on public.t_mixed
+         Output: b
+         Columnar Projected Columns: b
 (5 rows)
 
 DROP TABLE t_mixed;

--- a/columnar/src/test/regress/expected/columnar_aggregates_1.out
+++ b/columnar/src/test/regress/expected/columnar_aggregates_1.out
@@ -197,7 +197,7 @@ EXPLAIN (verbose, costs off, timing off, summary off) SELECT MIN(d) FROM t_mixed
          Columnar Projected Columns: d
 (5 rows)
 
---Unsupported aggregate argument combination.
+-- Unsupported aggregate argument combination.
 EXPLAIN (verbose, costs off, timing off, summary off) SELECT SUM(a + b) FROM t_mixed;
                      QUERY PLAN                     
 ----------------------------------------------------
@@ -227,6 +227,18 @@ EXPLAIN (verbose, costs off, timing off, summary off) SELECT COUNT(DISTINCT a) F
    ->  Custom Scan (ColumnarScan) on public.t_mixed
          Output: a
          Columnar Projected Columns: a
+(5 rows)
+
+-- github#145
+-- Vectorized aggregate doesn't accept function as argument
+EXPLAIN (verbose, costs off, timing off, summary off) SELECT SUM(length(b::text)) FROM t_mixed;
+                     QUERY PLAN                     
+----------------------------------------------------
+ Aggregate
+   Output: sum(length((b)::text))
+   ->  Custom Scan (ColumnarScan) on public.t_mixed
+         Output: b
+         Columnar Projected Columns: b
 (5 rows)
 
 DROP TABLE t_mixed;

--- a/columnar/src/test/regress/sql/columnar_aggregates.sql
+++ b/columnar/src/test/regress/sql/columnar_aggregates.sql
@@ -92,7 +92,7 @@ INSERT INTO t_mixed VALUES (0, 1000, '2000-01-01', '23:50'), (10, 2000, '2010-01
 
 EXPLAIN (verbose, costs off, timing off, summary off) SELECT MIN(d) FROM t_mixed;
 
---Unsupported aggregate argument combination.
+-- Unsupported aggregate argument combination.
 
 EXPLAIN (verbose, costs off, timing off, summary off) SELECT SUM(a + b) FROM t_mixed;
 
@@ -103,6 +103,11 @@ EXPLAIN (verbose, costs off, timing off, summary off) SELECT COUNT(1) FROM t_mix
 -- Vectorized aggregate with DISTINCT not supported.
 
 EXPLAIN (verbose, costs off, timing off, summary off) SELECT COUNT(DISTINCT a) FROM t_mixed;
+
+-- github#145
+-- Vectorized aggregate doesn't accept function as argument
+
+EXPLAIN (verbose, costs off, timing off, summary off) SELECT SUM(length(b::text)) FROM t_mixed;
 
 DROP TABLE t_mixed;
 


### PR DESCRIPTION
When custom vectorized aggregates exeuction checks argument it should allow only column argument and reject other argments (const, function, ...).

Fixes github#145.