### PR TITLE
[columnar] modify default qual_pushdown_correlation_threshold

### DIFF
--- a/columnar/src/backend/columnar/columnar_customscan.c
+++ b/columnar/src/backend/columnar/columnar_customscan.c
@@ -287,7 +287,7 @@ columnar_customscan_init()
 					 "is uncorrelated."),
 		NULL,
 		&ColumnarQualPushdownCorrelationThreshold,
-		0.9,
+		0.4,
 		0.0,
 		1.0,
 		PGC_USERSET,


### PR DESCRIPTION
The current value of `0.9` (on a scale of `0.0` to `1.0`) means that most quals will not be pushed down and thereby no chunk elimination occurs.  this PR lowers that value to `0.4`, which seems to work well in testing against both the clickbench and warehouse benchmarks.

