### PR TITLE
[columnar] speculative insert

### DIFF
--- a/columnar/src/backend/columnar/columnar_metadata.c
+++ b/columnar/src/backend/columnar/columnar_metadata.c
@@ -937,6 +937,17 @@ UpdateRowMask(RelFileNode relfilenode, uint64 storageId,
 
 			rowMask = rowMaskEntry->mask;
 		}
+		else
+		{
+			/*
+			* If the heap tuple is invalid, that likely means that we have
+			* encountered a speculative insert.
+			*/
+			systable_endscan_ordered(scanDescriptor);
+			index_close(index, AccessShareLock);
+			table_close(columnarRowMask, AccessShareLock);
+			return false;
+		}
 
 		systable_endscan_ordered(scanDescriptor);
 		index_close(index, AccessShareLock);

--- a/columnar/src/test/regress/columnar_schedule
+++ b/columnar/src/test/regress/columnar_schedule
@@ -35,3 +35,4 @@ test: columnar_matview
 test: columnar_alter_table_set_access_method
 test: columnar_cache
 test: columnar_aggregates
+test: columnar_upsert

--- a/columnar/src/test/regress/expected/columnar_upsert.out
+++ b/columnar/src/test/regress/expected/columnar_upsert.out
@@ -1,0 +1,58 @@
+CREATE TABLE upsert_test (
+  i INT,
+  t TEXT
+) USING columnar;
+CREATE UNIQUE INDEX ON upsert_test (t);
+INSERT INTO upsert_test (i, t) VALUES (1, 'hello');
+INSERT INTO upsert_test (i, t) VALUES (2, 'world');
+-- should work, then roll back
+BEGIN;
+INSERT INTO upsert_test (t) VALUES ( 'hello' ) ON CONFLICT (t) DO UPDATE SET t = 'foo';
+SELECT * FROM upsert_test;
+ i |   t   
+---+-------
+ 2 | world
+ 1 | foo
+(2 rows)
+
+ROLLBACK;
+SELECT * FROM upsert_test;
+ i |   t   
+---+-------
+ 1 | hello
+ 2 | world
+(2 rows)
+
+-- should take affect immediately
+INSERT INTO upsert_test (t) VALUES ( 'hello' ) ON CONFLICT (t) DO UPDATE SET t = 'bar';
+SELECT * FROM upsert_test;
+ i |   t   
+---+-------
+ 2 | world
+ 1 | bar
+(2 rows)
+
+-- should work as expected
+BEGIN;
+INSERT INTO upsert_test (t) VALUES ( 'world' ) ON CONFLICT (t) DO UPDATE SET t = 'foo';
+SELECT * FROM upsert_test;
+ i |  t  
+---+-----
+ 1 | bar
+ 2 | foo
+(2 rows)
+
+COMMIT;
+-- should also work as expected, a select can mask a bug
+DELETE FROM upsert_test;
+BEGIN;
+INSERT INTO upsert_test (i, t) VALUES (1, 'hello');
+INSERT INTO upsert_test (t) VALUES ( 'hello' ) ON CONFLICT (t) DO UPDATE SET t = 'bar';
+COMMIT;
+SELECT * FROM upsert_test;
+ i |  t  
+---+-----
+ 1 | bar
+(1 row)
+
+DROP TABLE upsert_test;

--- a/columnar/src/test/regress/sql/columnar_upsert.sql
+++ b/columnar/src/test/regress/sql/columnar_upsert.sql
@@ -1,0 +1,38 @@
+CREATE TABLE upsert_test (
+  i INT,
+  t TEXT
+) USING columnar;
+
+CREATE UNIQUE INDEX ON upsert_test (t);
+
+INSERT INTO upsert_test (i, t) VALUES (1, 'hello');
+INSERT INTO upsert_test (i, t) VALUES (2, 'world');
+
+-- should work, then roll back
+BEGIN;
+INSERT INTO upsert_test (t) VALUES ( 'hello' ) ON CONFLICT (t) DO UPDATE SET t = 'foo';
+SELECT * FROM upsert_test;
+ROLLBACK;
+
+SELECT * FROM upsert_test;
+
+-- should take affect immediately
+INSERT INTO upsert_test (t) VALUES ( 'hello' ) ON CONFLICT (t) DO UPDATE SET t = 'bar';
+SELECT * FROM upsert_test;
+
+-- should work as expected
+BEGIN;
+INSERT INTO upsert_test (t) VALUES ( 'world' ) ON CONFLICT (t) DO UPDATE SET t = 'foo';
+SELECT * FROM upsert_test;
+COMMIT;
+
+-- should also work as expected, a select can mask a bug
+DELETE FROM upsert_test;
+BEGIN;
+INSERT INTO upsert_test (i, t) VALUES (1, 'hello');
+INSERT INTO upsert_test (t) VALUES ( 'hello' ) ON CONFLICT (t) DO UPDATE SET t = 'bar';
+COMMIT;
+
+SELECT * FROM upsert_test;
+
+DROP TABLE upsert_test;


### PR DESCRIPTION
This PR adds speculative insert (upsert) to the columnar extension.

As part of that, there is a new `spec_mask` column added to `columnar.row_mask`.  it is extremely important that the upgrade script be run to update the extension.

Note that this should be tested extensively before being merged, as it has a direct impact on data storage.
