### PR TITLE
[columnar] Don't use vectorized aggregates if FILTER is used

### DIFF
--- a/columnar/src/backend/columnar/columnar_planner_hook.c
+++ b/columnar/src/backend/columnar/columnar_planner_hook.c
@@ -131,6 +131,11 @@ ExpressionMutator(Node *node, void *context)
 			elog(ERROR, "Vectorized aggregate with DISTINCT not supported.");
 		}
 
+		if (oldAggRefNode->aggfilter)
+		{
+			elog(ERROR, "Vectorized aggregate with FILTER not supported");
+		}
+
 		newAggRefNode->args = (List *)
 			expression_tree_mutator((Node *) oldAggRefNode->args, AggRefArgsExpressionMutator, NULL);
 		

--- a/columnar/src/test/regress/expected/columnar_aggregates.out
+++ b/columnar/src/test/regress/expected/columnar_aggregates.out
@@ -252,4 +252,30 @@ DETAIL:  Vectorized Aggregates accepts accepts only valid column argument
 (5 rows)
 
 DROP TABLE t_mixed;
+-- github#180
+-- Vectorized aggregate does't accept filter on columns
+CREATE TABLE t_filter(a INT) USING columnar;
+INSERT INTO t_filter SELECT g FROM GENERATE_SERIES(0,100) g;
+DEBUG:  Flushing Stripe of size 101
+EXPLAIN (verbose, costs off, timing off, summary off) SELECT COUNT(a) FILTER (WHERE a > 90) FROM t_filter;
+DEBUG:  Query can't be vectorized. Falling back to original execution.
+DETAIL:  Vectorized aggregate with FILTER not supported
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Aggregate
+   Output: count(a) FILTER (WHERE (a > 90))
+   ->  Custom Scan (ColumnarScan) on public.t_filter
+         Output: a
+         Columnar Projected Columns: a
+(5 rows)
+
+SELECT COUNT(a) FILTER (WHERE a > 90) FROM t_filter;
+DEBUG:  Query can't be vectorized. Falling back to original execution.
+DETAIL:  Vectorized aggregate with FILTER not supported
+ count 
+-------
+    10
+(1 row)
+
+DROP TABLE t_filter;
 SET client_min_messages TO default;

--- a/columnar/src/test/regress/expected/columnar_aggregates_1.out
+++ b/columnar/src/test/regress/expected/columnar_aggregates_1.out
@@ -242,4 +242,26 @@ EXPLAIN (verbose, costs off, timing off, summary off) SELECT SUM(length(b::text)
 (5 rows)
 
 DROP TABLE t_mixed;
+-- github#180
+-- Vectorized aggregate does't accept filter on columns
+CREATE TABLE t_filter(a INT) USING columnar;
+INSERT INTO t_filter SELECT g FROM GENERATE_SERIES(0,100) g;
+DEBUG:  Flushing Stripe of size 101
+EXPLAIN (verbose, costs off, timing off, summary off) SELECT COUNT(a) FILTER (WHERE a > 90) FROM t_filter;
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Aggregate
+   Output: count(a) FILTER (WHERE (a > 90))
+   ->  Custom Scan (ColumnarScan) on public.t_filter
+         Output: a
+         Columnar Projected Columns: a
+(5 rows)
+
+SELECT COUNT(a) FILTER (WHERE a > 90) FROM t_filter;
+ count 
+-------
+    10
+(1 row)
+
+DROP TABLE t_filter;
 SET client_min_messages TO default;

--- a/columnar/src/test/regress/sql/columnar_aggregates.sql
+++ b/columnar/src/test/regress/sql/columnar_aggregates.sql
@@ -111,4 +111,17 @@ EXPLAIN (verbose, costs off, timing off, summary off) SELECT SUM(length(b::text)
 
 DROP TABLE t_mixed;
 
+-- github#180
+-- Vectorized aggregate does't accept filter on columns
+
+CREATE TABLE t_filter(a INT) USING columnar;
+
+INSERT INTO t_filter SELECT g FROM GENERATE_SERIES(0,100) g;
+
+EXPLAIN (verbose, costs off, timing off, summary off) SELECT COUNT(a) FILTER (WHERE a > 90) FROM t_filter;
+
+SELECT COUNT(a) FILTER (WHERE a > 90) FROM t_filter;
+
+DROP TABLE t_filter;
+
 SET client_min_messages TO default;


### PR DESCRIPTION
* Don't use vectorized aggregates if FILTER is used. FILTER is part of aggregate node execution - not part of custom scan.
