### PR TITLE
[columnar] Force trigger and constraint checks after every multi-insert

### DIFF
--- a/columnar/src/backend/columnar/columnar_metadata.c
+++ b/columnar/src/backend/columnar/columnar_metadata.c
@@ -132,7 +132,6 @@ static void InsertTupleAndEnforceConstraints(ModifyState *state, Datum *values,
 											 bool *nulls);
 static void DeleteTupleAndEnforceConstraints(ModifyState *state, HeapTuple heapTuple);
 static void FinishModifyRelation(ModifyState *state);
-static EState * create_estate_for_relation(Relation rel);
 static bytea * DatumToBytea(Datum value, Form_pg_attribute attrForm);
 static Datum ByteaToDatum(bytea *bytes, Form_pg_attribute attrForm);
 static bool WriteColumnarOptions(Oid regclass, ColumnarOptions *options, bool overwrite);
@@ -2079,7 +2078,7 @@ FinishModifyRelation(ModifyState *state)
  *
  * This is based on similar code in copy.c
  */
-static EState *
+EState *
 create_estate_for_relation(Relation rel)
 {
 	EState *estate = CreateExecutorState();

--- a/columnar/src/include/columnar/columnar.h
+++ b/columnar/src/include/columnar/columnar.h
@@ -375,6 +375,7 @@ extern bytea * ReadChunkRowMask(RelFileNode relfilenode, Snapshot snapshot,
 								MemoryContext ctx,
 								uint64 stripeFirstRowNumber, int rowCount);
 extern Datum create_table_row_mask(PG_FUNCTION_ARGS);
+extern EState * create_estate_for_relation(Relation rel);
 
 /* columnar_planner_hook.c */
 extern void columnar_planner_init(void);


### PR DESCRIPTION
As noted in #177, during a multi-insert, we were blindly inserting all data without doing any constraint or trigger checks.

This PR adds the constraint and trigger checks in.

This will likely have an affect on multi-insert (`COPY`) speed, but is now correct instead of allowing for duplicates when they should not be allowed.