### PR TITLE
Vacuum large blocks

### DIFF
--- a/columnar/src/backend/columnar/columnar_metadata.c
+++ b/columnar/src/backend/columnar/columnar_metadata.c
@@ -1402,7 +1402,8 @@ ReadChunkGroupRowCounts(uint64 storageId, uint64 stripe, uint32 chunkGroupCount,
 
 		if (tupleChunkGroupIndex > chunkGroupCount)
 		{
-			elog(ERROR, "Tuple chunk group higher than chunk group count");
+			elog(WARNING, "Tuple chunk group higher than chunk group count: %d, %d (storage_id = %ld, stripe_id = %ld)", tupleChunkGroupIndex, chunkGroupCount, UInt64GetDatum(storageId), Int64GetDatum(stripe));
+			tupleChunkGroupIndex = chunkGroupCount;
 		}
 
 		(*chunkGroupRowCounts)[tupleChunkGroupIndex] =

--- a/columnar/src/include/columnar/columnar_metadata.h
+++ b/columnar/src/include/columnar/columnar_metadata.h
@@ -55,6 +55,7 @@ extern List * StripesForRelfilenode(RelFileLocator relfilelocator, ScanDirection
 extern uint32 DeletedRowsForStripe(RelFileLocator relfilelocator,
 								   uint32 chunkCount,
 								   uint64 stripeId);
+extern Size DecompressedLengthForStripe(RelFileLocator relfilelocator, uint64 stripeId);
 extern void ColumnarStorageUpdateIfNeeded(Relation rel, bool isUpgrade);
 extern StripeMetadata * RewriteStripeMetadataRowWithNewValues(Relation rel, uint64 stripeId,
               uint64 sizeBytes, uint64 fileOffset, uint64 rowCount, uint64 chunkCount);

--- a/columnar/src/test/regress/expected/columnar_vacuum.out
+++ b/columnar/src/test/regress/expected/columnar_vacuum.out
@@ -441,3 +441,10 @@ SELECT COUNT(*) = (:columnar_row_mask_rows / 2) FROM columnar.row_mask WHERE sto
 (1 row)
 
 DROP TABLE t;
+-- Verify that we can vacuum humongous fields
+CREATE TABLE t (id SERIAL, data TEXT) USING columnar;
+INSERT INTO t SELECT 1, repeat('a', 1000000000);
+INSERT INTO t SELECT 2, repeat('b', 1000000000);
+INSERT INTO t SELECT 3, repeat('c', 1000000000);
+VACUUM t;
+DROP TABLE t;

--- a/columnar/src/test/regress/sql/columnar_vacuum.sql
+++ b/columnar/src/test/regress/sql/columnar_vacuum.sql
@@ -243,3 +243,13 @@ SELECT COUNT(*) = (:columnar_chunk_group_rows / 2) FROM columnar.chunk_group WHE
 SELECT COUNT(*) = (:columnar_row_mask_rows / 2) FROM columnar.row_mask WHERE storage_id = :t_oid;
 
 DROP TABLE t;
+
+-- Verify that we can vacuum humongous fields
+CREATE TABLE t (id SERIAL, data TEXT) USING columnar;
+INSERT INTO t SELECT 1, repeat('a', 1000000000);
+INSERT INTO t SELECT 2, repeat('b', 1000000000);
+INSERT INTO t SELECT 3, repeat('c', 1000000000);
+
+VACUUM t;
+
+DROP TABLE t;


### PR DESCRIPTION
there is an issue when dealing with very large fields (near 1gb) are inserted into a columnar store.  a vacuum (or auto-vacuum) is performed, which is unable to combine.

this fixes that, and decompression.