### PR TITLE
[columnar] HYD-760 Serialization fails to copy data

### DIFF
--- a/columnar/src/backend/columnar/columnar_metadata.c
+++ b/columnar/src/backend/columnar/columnar_metadata.c
@@ -2208,20 +2208,16 @@ DatumToBytea(Datum value, Form_pg_attribute attrForm)
 		{
 			Datum tmp;
 			store_att_byval(&tmp, value, attrForm->attlen);
-
-			memcpy_s(VARDATA(result), datumLength + VARHDRSZ,
-					 &tmp, attrForm->attlen);
+			memcpy(VARDATA(result), &tmp, attrForm->attlen);
 		}
 		else
 		{
-			memcpy_s(VARDATA(result), datumLength + VARHDRSZ,
-					 DatumGetPointer(value), attrForm->attlen);
+			memcpy(VARDATA(result), DatumGetPointer(value), attrForm->attlen);
 		}
 	}
 	else
 	{
-		memcpy_s(VARDATA(result), datumLength + VARHDRSZ,
-				 DatumGetPointer(value), datumLength);
+		memcpy(VARDATA(result), DatumGetPointer(value), datumLength);
 	}
 
 	return result;
@@ -2240,7 +2236,7 @@ ByteaToDatum(bytea *bytes, Form_pg_attribute attrForm)
 	 * after the byteaDatum is freed.
 	 */
 	char *binaryDataCopy = palloc0(VARSIZE_ANY_EXHDR(bytes));
-	memcpy_s(binaryDataCopy, VARSIZE_ANY_EXHDR(bytes),
+	memcpy(binaryDataCopy, /*VARSIZE_ANY_EXHDR(bytes),*/
 			 VARDATA_ANY(bytes), VARSIZE_ANY_EXHDR(bytes));
 
 	return fetch_att(binaryDataCopy, attrForm->attbyval, attrForm->attlen);

--- a/columnar/src/backend/columnar/columnar_tableam.c
+++ b/columnar/src/backend/columnar/columnar_tableam.c
@@ -3032,8 +3032,7 @@ detoast_values(TupleDesc tupleDesc, Datum *orig_values, bool *isnull)
 			if (values == orig_values)
 			{
 				values = palloc(sizeof(Datum) * natts);
-				memcpy_s(values, sizeof(Datum) * natts,
-						 orig_values, sizeof(Datum) * natts);
+				memcpy(values, orig_values, sizeof(Datum) * natts);
 			}
 
 			/* will be freed when per-tuple context is reset */

--- a/columnar/src/backend/columnar/columnar_writer.c
+++ b/columnar/src/backend/columnar/columnar_writer.c
@@ -627,15 +627,13 @@ SerializeSingleDatum(StringInfo datumBuffer, Datum datum, bool datumTypeByValue,
 		}
 		else
 		{
-			memcpy_s(currentDatumDataPointer, datumBuffer->maxlen - datumBuffer->len,
-					 DatumGetPointer(datum), datumTypeLength);
+			memcpy(currentDatumDataPointer, DatumGetPointer(datum), datumTypeLength);
 		}
 	}
 	else
 	{
 		Assert(!datumTypeByValue);
-		memcpy_s(currentDatumDataPointer, datumBuffer->maxlen - datumBuffer->len,
-				 DatumGetPointer(datum), datumLength);
+		memcpy(currentDatumDataPointer, DatumGetPointer(datum), datumLength);
 	}
 
 	datumBuffer->len += datumLengthAligned;
@@ -790,7 +788,7 @@ DatumCopy(Datum datum, bool datumTypeByValue, int datumTypeLength)
 	{
 		uint32 datumLength = att_addlength_datum(0, datumTypeLength, datum);
 		char *datumData = palloc0(datumLength);
-		memcpy_s(datumData, datumLength, DatumGetPointer(datum), datumLength);
+		memcpy(datumData, DatumGetPointer(datum), datumLength);
 
 		datumCopy = PointerGetDatum(datumData);
 	}
@@ -813,8 +811,7 @@ CopyStringInfo(StringInfo sourceString)
 		targetString->data = palloc0(sourceString->len);
 		targetString->len = sourceString->len;
 		targetString->maxlen = sourceString->len;
-		memcpy_s(targetString->data, sourceString->len,
-				 sourceString->data, sourceString->len);
+		memcpy(targetString->data, sourceString->data, sourceString->len);
 	}
 
 	return targetString;

--- a/columnar/src/test/regress/expected/columnar_insert.out
+++ b/columnar/src/test/regress/expected/columnar_insert.out
@@ -310,3 +310,13 @@ DETAIL:  This can happen after a roll-back.
 RESET search_path;
 SET client_min_messages TO WARNING;
 DROP SCHEMA columnar_insert CASCADE;
+--- HYD-760
+CREATE TABLE t_text(t text) USING columnar;
+INSERT INTO t_text SELECT repeat('a', 100000) FROM generate_series(1, 500000) a;
+SELECT length(t), count(length(t)) FROM t_text GROUP BY length(t);
+ length | count  
+--------+--------
+ 100000 | 500000
+(1 row)
+
+DROP TABLE t_text;

--- a/columnar/src/test/regress/expected/columnar_insert_1.out
+++ b/columnar/src/test/regress/expected/columnar_insert_1.out
@@ -310,3 +310,13 @@ DETAIL:  This can happen after a roll-back.
 RESET search_path;
 SET client_min_messages TO WARNING;
 DROP SCHEMA columnar_insert CASCADE;
+--- HYD-760
+CREATE TABLE t_text(t text) USING columnar;
+INSERT INTO t_text SELECT repeat('a', 100000) FROM generate_series(1, 500000) a;
+SELECT length(t), count(length(t)) FROM t_text GROUP BY length(t);
+ length | count  
+--------+--------
+ 100000 | 500000
+(1 row)
+
+DROP TABLE t_text;

--- a/columnar/src/test/regress/expected/columnar_insert_2.out
+++ b/columnar/src/test/regress/expected/columnar_insert_2.out
@@ -310,3 +310,13 @@ DETAIL:  This can happen after a roll-back.
 RESET search_path;
 SET client_min_messages TO WARNING;
 DROP SCHEMA columnar_insert CASCADE;
+--- HYD-760
+CREATE TABLE t_text(t text) USING columnar;
+INSERT INTO t_text SELECT repeat('a', 100000) FROM generate_series(1, 500000) a;
+SELECT length(t), count(length(t)) FROM t_text GROUP BY length(t);
+ length | count  
+--------+--------
+ 100000 | 500000
+(1 row)
+
+DROP TABLE t_text;

--- a/columnar/src/test/regress/sql/columnar_insert.sql
+++ b/columnar/src/test/regress/sql/columnar_insert.sql
@@ -213,3 +213,9 @@ RESET search_path;
 SET client_min_messages TO WARNING;
 DROP SCHEMA columnar_insert CASCADE;
 
+--- HYD-760
+
+CREATE TABLE t_text(t text) USING columnar;
+INSERT INTO t_text SELECT repeat('a', 100000) FROM generate_series(1, 500000) a;
+SELECT length(t), count(length(t)) FROM t_text GROUP BY length(t);
+DROP TABLE t_text;


### PR DESCRIPTION
* When we are building chunk for serialization if serialzation memory is higher than 256MB, memcpy_s function (safeclib) will not copy anything (there is memory size check). Fixed by using memcpy. We have allocated already memory with required size so it should be safe to copy it.