### PR TITLE
[columnar] HYD-761 Set maximum column size

### DIFF
--- a/columnar/src/backend/columnar/columnar_metadata.c
+++ b/columnar/src/backend/columnar/columnar_metadata.c
@@ -2208,20 +2208,16 @@ DatumToBytea(Datum value, Form_pg_attribute attrForm)
 		{
 			Datum tmp;
 			store_att_byval(&tmp, value, attrForm->attlen);
-
-			memcpy_s(VARDATA(result), datumLength + VARHDRSZ,
-					 &tmp, attrForm->attlen);
+			memcpy(VARDATA(result), &tmp, attrForm->attlen);
 		}
 		else
 		{
-			memcpy_s(VARDATA(result), datumLength + VARHDRSZ,
-					 DatumGetPointer(value), attrForm->attlen);
+			memcpy(VARDATA(result), DatumGetPointer(value), attrForm->attlen);
 		}
 	}
 	else
 	{
-		memcpy_s(VARDATA(result), datumLength + VARHDRSZ,
-				 DatumGetPointer(value), datumLength);
+		memcpy(VARDATA(result), DatumGetPointer(value), datumLength);
 	}
 
 	return result;
@@ -2240,7 +2236,7 @@ ByteaToDatum(bytea *bytes, Form_pg_attribute attrForm)
 	 * after the byteaDatum is freed.
 	 */
 	char *binaryDataCopy = palloc0(VARSIZE_ANY_EXHDR(bytes));
-	memcpy_s(binaryDataCopy, VARSIZE_ANY_EXHDR(bytes),
+	memcpy(binaryDataCopy, /*VARSIZE_ANY_EXHDR(bytes),*/
 			 VARDATA_ANY(bytes), VARSIZE_ANY_EXHDR(bytes));
 
 	return fetch_att(binaryDataCopy, attrForm->attbyval, attrForm->attlen);

--- a/columnar/src/backend/columnar/columnar_tableam.c
+++ b/columnar/src/backend/columnar/columnar_tableam.c
@@ -3032,8 +3032,7 @@ detoast_values(TupleDesc tupleDesc, Datum *orig_values, bool *isnull)
 			if (values == orig_values)
 			{
 				values = palloc(sizeof(Datum) * natts);
-				memcpy_s(values, sizeof(Datum) * natts,
-						 orig_values, sizeof(Datum) * natts);
+				memcpy(values, orig_values, sizeof(Datum) * natts);
 			}
 
 			/* will be freed when per-tuple context is reset */

--- a/columnar/src/backend/columnar/columnar_writer.c
+++ b/columnar/src/backend/columnar/columnar_writer.c
@@ -627,15 +627,13 @@ SerializeSingleDatum(StringInfo datumBuffer, Datum datum, bool datumTypeByValue,
 		}
 		else
 		{
-			memcpy_s(currentDatumDataPointer, datumBuffer->maxlen - datumBuffer->len,
-					 DatumGetPointer(datum), datumTypeLength);
+			memcpy(currentDatumDataPointer, DatumGetPointer(datum), datumTypeLength);
 		}
 	}
 	else
 	{
 		Assert(!datumTypeByValue);
-		memcpy_s(currentDatumDataPointer, datumBuffer->maxlen - datumBuffer->len,
-				 DatumGetPointer(datum), datumLength);
+		memcpy(currentDatumDataPointer, DatumGetPointer(datum), datumLength);
 	}
 
 	datumBuffer->len += datumLengthAligned;
@@ -790,7 +788,7 @@ DatumCopy(Datum datum, bool datumTypeByValue, int datumTypeLength)
 	{
 		uint32 datumLength = att_addlength_datum(0, datumTypeLength, datum);
 		char *datumData = palloc0(datumLength);
-		memcpy_s(datumData, datumLength, DatumGetPointer(datum), datumLength);
+		memcpy(datumData, DatumGetPointer(datum), datumLength);
 
 		datumCopy = PointerGetDatum(datumData);
 	}
@@ -813,8 +811,7 @@ CopyStringInfo(StringInfo sourceString)
 		targetString->data = palloc0(sourceString->len);
 		targetString->len = sourceString->len;
 		targetString->maxlen = sourceString->len;
-		memcpy_s(targetString->data, sourceString->len,
-				 sourceString->data, sourceString->len);
+		memcpy(targetString->data, sourceString->data, sourceString->len);
 	}
 
 	return targetString;

--- a/columnar/src/test/regress/expected/columnar_alter_set_type.out
+++ b/columnar/src/test/regress/expected/columnar_alter_set_type.out
@@ -63,7 +63,7 @@ SELECT columnar.alter_columnar_table_set('test', compression => 'lz4');
 INSERT INTO test VALUES(1);
 VACUUM VERBOSE test;
 INFO:  statistics for "test":
-storage id: 10000000139
+storage id: 10000000141
 total file size: 24576, total data size: 6
 compression rate: 0.83x
 total row count: 1, stripe count: 1, average rows per stripe: 1
@@ -72,7 +72,7 @@ chunk count: 1, containing data for dropped columns: 0, lz4 compressed: 1
 ALTER TABLE test ALTER COLUMN i TYPE int8;
 VACUUM VERBOSE test;
 INFO:  statistics for "test":
-storage id: 10000000140
+storage id: 10000000142
 total file size: 24576, total data size: 10
 compression rate: 0.90x
 total row count: 1, stripe count: 1, average rows per stripe: 1

--- a/columnar/src/test/regress/expected/columnar_insert.out
+++ b/columnar/src/test/regress/expected/columnar_insert.out
@@ -310,3 +310,13 @@ DETAIL:  This can happen after a roll-back.
 RESET search_path;
 SET client_min_messages TO WARNING;
 DROP SCHEMA columnar_insert CASCADE;
+--- HYD-760
+CREATE TABLE t_text(t text) USING columnar;
+INSERT INTO t_text SELECT repeat('a', 100000) FROM generate_series(1, 500000) a;
+SELECT length(t), count(length(t)) FROM t_text GROUP BY length(t);
+ length | count  
+--------+--------
+ 100000 | 500000
+(1 row)
+
+DROP TABLE t_text;

--- a/columnar/src/test/regress/expected/columnar_insert.out
+++ b/columnar/src/test/regress/expected/columnar_insert.out
@@ -320,3 +320,11 @@ SELECT length(t), count(length(t)) FROM t_text GROUP BY length(t);
 (1 row)
 
 DROP TABLE t_text;
+--- HYD-761
+CREATE TABLE t_huge_column(t text) USING columnar;
+INSERT INTO t_huge_column SELECT repeat('a', 1000000000);
+ERROR:  Error with insert on column 't'. Inserting 1000000004 bytes, exceeding 256MB
+INSERT INTO t_huge_column SELECT repeat('a',  500000000);
+ERROR:  Error with insert on column 't'. Inserting 500000004 bytes, exceeding 256MB
+INSERT INTO t_huge_column SELECT repeat('a',  255000000);
+DROP TABLE t_huge_column;

--- a/columnar/src/test/regress/expected/columnar_insert_1.out
+++ b/columnar/src/test/regress/expected/columnar_insert_1.out
@@ -310,3 +310,13 @@ DETAIL:  This can happen after a roll-back.
 RESET search_path;
 SET client_min_messages TO WARNING;
 DROP SCHEMA columnar_insert CASCADE;
+--- HYD-760
+CREATE TABLE t_text(t text) USING columnar;
+INSERT INTO t_text SELECT repeat('a', 100000) FROM generate_series(1, 500000) a;
+SELECT length(t), count(length(t)) FROM t_text GROUP BY length(t);
+ length | count  
+--------+--------
+ 100000 | 500000
+(1 row)
+
+DROP TABLE t_text;

--- a/columnar/src/test/regress/expected/columnar_insert_1.out
+++ b/columnar/src/test/regress/expected/columnar_insert_1.out
@@ -320,3 +320,11 @@ SELECT length(t), count(length(t)) FROM t_text GROUP BY length(t);
 (1 row)
 
 DROP TABLE t_text;
+--- HYD-761
+CREATE TABLE t_huge_column(t text) USING columnar;
+INSERT INTO t_huge_column SELECT repeat('a', 1000000000);
+ERROR:  Error with insert on column 't'. Inserting 1000000004 bytes, exceeding 256MB
+INSERT INTO t_huge_column SELECT repeat('a',  500000000);
+ERROR:  Error with insert on column 't'. Inserting 500000004 bytes, exceeding 256MB
+INSERT INTO t_huge_column SELECT repeat('a',  255000000);
+DROP TABLE t_huge_column;

--- a/columnar/src/test/regress/expected/columnar_insert_2.out
+++ b/columnar/src/test/regress/expected/columnar_insert_2.out
@@ -310,3 +310,13 @@ DETAIL:  This can happen after a roll-back.
 RESET search_path;
 SET client_min_messages TO WARNING;
 DROP SCHEMA columnar_insert CASCADE;
+--- HYD-760
+CREATE TABLE t_text(t text) USING columnar;
+INSERT INTO t_text SELECT repeat('a', 100000) FROM generate_series(1, 500000) a;
+SELECT length(t), count(length(t)) FROM t_text GROUP BY length(t);
+ length | count  
+--------+--------
+ 100000 | 500000
+(1 row)
+
+DROP TABLE t_text;

--- a/columnar/src/test/regress/expected/columnar_insert_2.out
+++ b/columnar/src/test/regress/expected/columnar_insert_2.out
@@ -320,3 +320,11 @@ SELECT length(t), count(length(t)) FROM t_text GROUP BY length(t);
 (1 row)
 
 DROP TABLE t_text;
+--- HYD-761
+CREATE TABLE t_huge_column(t text) USING columnar;
+INSERT INTO t_huge_column SELECT repeat('a', 1000000000);
+ERROR:  Error with insert on column 't'. Inserting 1000000004 bytes, exceeding 256MB
+INSERT INTO t_huge_column SELECT repeat('a',  500000000);
+ERROR:  Error with insert on column 't'. Inserting 500000004 bytes, exceeding 256MB
+INSERT INTO t_huge_column SELECT repeat('a',  255000000);
+DROP TABLE t_huge_column;

--- a/columnar/src/test/regress/expected/columnar_vacuum.out
+++ b/columnar/src/test/regress/expected/columnar_vacuum.out
@@ -443,8 +443,32 @@ SELECT COUNT(*) = (:columnar_row_mask_rows / 2) FROM columnar.row_mask WHERE sto
 DROP TABLE t;
 -- Verify that we can vacuum humongous fields
 CREATE TABLE t (id SERIAL, data TEXT) USING columnar;
-INSERT INTO t SELECT 1, repeat('a', 1000000000);
-INSERT INTO t SELECT 2, repeat('b', 1000000000);
-INSERT INTO t SELECT 3, repeat('c', 1000000000);
+SELECT columnar_test_helpers.columnar_relation_storageid(pg_class.oid) AS t_oid FROM pg_class WHERE relname='t' \gset
+INSERT INTO t SELECT 1, repeat('a', 255000000);
+INSERT INTO t SELECT 2, repeat('b', 255000000);
+INSERT INTO t SELECT 3, repeat('c', 255000000);
+INSERT INTO t SELECT 4, repeat('d', 255000000);
+INSERT INTO t SELECT 5, repeat('e', 255000000);
+INSERT INTO t SELECT 6, repeat('f', 255000000);
+SELECT COUNT(*) = 6 FROM columnar.stripe WHERE storage_id = :t_oid;
+ ?column? 
+----------
+ t
+(1 row)
+
 VACUUM t;
+SELECT COUNT(*) = 3 FROM columnar.stripe WHERE storage_id = :t_oid;
+ ?column? 
+----------
+ t
+(1 row)
+
+INSERT INTO t SELECT 7, repeat('g', 255000000);
+VACUUM t;
+SELECT COUNT(*) = 4 FROM columnar.stripe WHERE storage_id = :t_oid;
+ ?column? 
+----------
+ t
+(1 row)
+
 DROP TABLE t;

--- a/columnar/src/test/regress/sql/columnar_insert.sql
+++ b/columnar/src/test/regress/sql/columnar_insert.sql
@@ -213,3 +213,9 @@ RESET search_path;
 SET client_min_messages TO WARNING;
 DROP SCHEMA columnar_insert CASCADE;
 
+--- HYD-760
+
+CREATE TABLE t_text(t text) USING columnar;
+INSERT INTO t_text SELECT repeat('a', 100000) FROM generate_series(1, 500000) a;
+SELECT length(t), count(length(t)) FROM t_text GROUP BY length(t);
+DROP TABLE t_text;

--- a/columnar/src/test/regress/sql/columnar_insert.sql
+++ b/columnar/src/test/regress/sql/columnar_insert.sql
@@ -219,3 +219,11 @@ CREATE TABLE t_text(t text) USING columnar;
 INSERT INTO t_text SELECT repeat('a', 100000) FROM generate_series(1, 500000) a;
 SELECT length(t), count(length(t)) FROM t_text GROUP BY length(t);
 DROP TABLE t_text;
+
+--- HYD-761
+
+CREATE TABLE t_huge_column(t text) USING columnar;
+INSERT INTO t_huge_column SELECT repeat('a', 1000000000);
+INSERT INTO t_huge_column SELECT repeat('a',  500000000);
+INSERT INTO t_huge_column SELECT repeat('a',  255000000);
+DROP TABLE t_huge_column;

--- a/columnar/src/test/regress/sql/columnar_vacuum.sql
+++ b/columnar/src/test/regress/sql/columnar_vacuum.sql
@@ -246,10 +246,26 @@ DROP TABLE t;
 
 -- Verify that we can vacuum humongous fields
 CREATE TABLE t (id SERIAL, data TEXT) USING columnar;
-INSERT INTO t SELECT 1, repeat('a', 1000000000);
-INSERT INTO t SELECT 2, repeat('b', 1000000000);
-INSERT INTO t SELECT 3, repeat('c', 1000000000);
+
+SELECT columnar_test_helpers.columnar_relation_storageid(pg_class.oid) AS t_oid FROM pg_class WHERE relname='t' \gset
+
+INSERT INTO t SELECT 1, repeat('a', 255000000);
+INSERT INTO t SELECT 2, repeat('b', 255000000);
+INSERT INTO t SELECT 3, repeat('c', 255000000);
+INSERT INTO t SELECT 4, repeat('d', 255000000);
+INSERT INTO t SELECT 5, repeat('e', 255000000);
+INSERT INTO t SELECT 6, repeat('f', 255000000);
+
+SELECT COUNT(*) = 6 FROM columnar.stripe WHERE storage_id = :t_oid;
 
 VACUUM t;
+
+SELECT COUNT(*) = 3 FROM columnar.stripe WHERE storage_id = :t_oid;
+
+INSERT INTO t SELECT 7, repeat('g', 255000000);
+
+VACUUM t;
+
+SELECT COUNT(*) = 4 FROM columnar.stripe WHERE storage_id = :t_oid;
 
 DROP TABLE t;


### PR DESCRIPTION
Metadata table is on heap. If we try to construct metadata row bigger than 1GB insert will fail at that point. Limit maximum column size to be 256MB.