### PR TITLE
Force UTF-8 locale for spilo image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -183,12 +183,16 @@ jobs:
           TEST_AWS_REGION: us-east-1
           TEST_AWS_S3_BUCKET: hydra-test-fixtures
         run: make spilo_acceptance_test
+      - name: tgz container logs
+        if: failure()
+        run: |
+          tar -czf /tmp/test_results.tar.gz ${{ env.TEST_ARTIFACT_DIR }}
       - name: Upload test container logs
         if: failure()
         uses: actions/upload-artifact@v3
         with:
           name: spilo_container_logs
-          path: ${{ env.TEST_ARTIFACT_DIR }}
+          path: /tmp/test_results.tar.gz
           retention-days: 7
       - name: Bake amd64 spilo
         if: github.ref == 'refs/heads/main'

--- a/Dockerfile.spilo
+++ b/Dockerfile.spilo
@@ -10,6 +10,13 @@ RUN set -eux; \
   ; \
   rm -rf /var/lib/apt/lists/*
 
+# See https://github.com/docker-library/postgres/issues/415
+RUN set -eux; \
+  locale-gen en_US.UTF-8; \
+  echo "LC_ALL=en_US.UTF-8" >> /etc/environment; \
+  echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen; \
+  echo "LANG=en_US.UTF-8" > /etc/locale.conf
+
 # columnar ext
 # NOTE(owenthereal): build columnar with pgxman in this repo
 COPY --from=columnar_13 /pg_ext /


### PR DESCRIPTION
### What's changed?

We are getting `initdb: error: invalid locale name “en_US.UTF-8”` in acceptance tests. This is related to https://github.com/docker-library/postgres/issues/1112. We are forcing UTF-8 as the locale for spilo image. Besides, this PR includes a fix to upload pg logs for spilo build. 

Successful splio build is in https://github.com/hydradatabase/hydra-internal/actions/runs/7506480250.