### PR TITLE
[columnar] Skip vectorization if custom scan is not ColumnarScan

### DIFF
--- a/columnar/src/backend/columnar/columnar_planner_hook.c
+++ b/columnar/src/backend/columnar/columnar_planner_hook.c
@@ -212,6 +212,10 @@ PlanTreeMutator(Plan *node, void *context)
 
 				customScan->custom_private = lappend(customScan->custom_private, vectorizedAggregateExecution);
 			}
+			else
+			{
+				elog(ERROR, "Custom Scan type is not ColumnarScan.");
+			}
 
 			break;
 		}


### PR DESCRIPTION
* In presence of another custom scan, aggregator node will be still vectorized which can be problematic. Skip vectorization if custom scan is differnt than ColumnarScan.