### PR TITLE
Fix a server crash

### DIFF
--- a/columnar/src/backend/columnar/columnar_reader.c
+++ b/columnar/src/backend/columnar/columnar_reader.c
@@ -2162,8 +2162,8 @@ ReadStripeNextVector(StripeReadState *stripeReadState, Datum *columnValues,
 			if (*newVectorSize == 0)
 				continue;
 		}
-
-		stripeReadState->currentRow += stripeReadState->chunkGroupReadState->rowCount;
+		else
+			stripeReadState->currentRow += stripeReadState->chunkGroupReadState->rowCount;
 
 		return true;
 	}

--- a/columnar/src/test/regress/expected/columnar_alter_set_type.out
+++ b/columnar/src/test/regress/expected/columnar_alter_set_type.out
@@ -63,7 +63,7 @@ SELECT columnar.alter_columnar_table_set('test', compression => 'lz4');
 INSERT INTO test VALUES(1);
 VACUUM VERBOSE test;
 INFO:  statistics for "test":
-storage id: 10000000141
+storage id: 10000000142
 total file size: 24576, total data size: 6
 compression rate: 0.83x
 total row count: 1, stripe count: 1, average rows per stripe: 1
@@ -72,7 +72,7 @@ chunk count: 1, containing data for dropped columns: 0, lz4 compressed: 1
 ALTER TABLE test ALTER COLUMN i TYPE int8;
 VACUUM VERBOSE test;
 INFO:  statistics for "test":
-storage id: 10000000142
+storage id: 10000000143
 total file size: 24576, total data size: 10
 compression rate: 0.90x
 total row count: 1, stripe count: 1, average rows per stripe: 1

--- a/columnar/src/test/regress/expected/columnar_query.out
+++ b/columnar/src/test/regress/expected/columnar_query.out
@@ -310,3 +310,21 @@ SELECT * FROM t WHERE a >= 90;
 (11 rows)
 
 DROP TABLE t;
+--
+-- [columnar] Test chunk_group_row_limit
+--
+CREATE TABLE t(a INT) USING columnar;
+SELECT columnar.alter_columnar_table_set('t', chunk_group_row_limit => '11000');
+ alter_columnar_table_set 
+--------------------------
+ 
+(1 row)
+
+INSERT INTO t SELECT a FROM generate_series(0,50000) AS a;
+SELECT count(*) FROM t;
+ count 
+-------
+ 50001
+(1 row)
+
+DROP TABLE t;

--- a/columnar/src/test/regress/sql/columnar_query.sql
+++ b/columnar/src/test/regress/sql/columnar_query.sql
@@ -160,3 +160,18 @@ SELECT * FROM t WHERE a >= 90;
 SELECT * FROM t WHERE a >= 90;
 
 DROP TABLE t;
+
+
+--
+-- [columnar] Test chunk_group_row_limit
+--
+
+CREATE TABLE t(a INT) USING columnar;
+
+SELECT columnar.alter_columnar_table_set('t', chunk_group_row_limit => '11000');
+
+INSERT INTO t SELECT a FROM generate_series(0,50000) AS a;
+
+SELECT count(*) FROM t;
+
+DROP TABLE t;


### PR DESCRIPTION
When `chunk_group_row_limit` is bigger than 110000, there is a crash caused by `ReadStripeNextVector()`.

For example:

```sql
CREATE TABLE t1 (id int, info text) USING columnar;
CREATE TABLE t2 (id int, info text) USING columnar;
SELECT columnar.alter_columnar_table_set('t1', chunk_group_row_limit => '10000');
SELECT columnar.alter_columnar_table_set('t2', chunk_group_row_limit => '11000');
INSERT INTO t1 SELECT id, md5(id::text) FROM generate_series(1, 10000000) id;
INSERT INTO t2 SELECT id, md5(id::text) FROM generate_series(1, 10000000) id;
```

```sql
[local]:345317 postgres=# SELECT count(*) FROM t1;
  count
----------
 10000000
(1 row)

[local]:345317 postgres=# SELECT count(*) FROM t2;
server closed the connection unexpectedly
        This probably means the server terminated abnormally
        before or while processing the request.
The connection to the server was lost. Attempting reset: Failed.
The connection to the server was lost. Attempting reset: Failed.
: !?>
```

PostgreSQL version 16.1, hydra columnar dd0ef07209dd.

```c
		if (!ReadChunkGroupNextVector(stripeReadState->chunkGroupReadState,
									  columnValues, columnNulls, 
									  stripeReadState->tupleDescriptor,
									  columnValueOffset, 
									  newVectorSize,
									  rowNumber,
									  chunkFirstRowNumber))
		{
			/* if this chunk group is exhausted, fetch the next one and loop */
			EndChunkGroupRead(stripeReadState->chunkGroupReadState);
			stripeReadState->chunkGroupReadState = NULL;
			stripeReadState->chunkGroupIndex++;

			if (*newVectorSize == 0)
				continue;
		}
		^----------> here the stripeReadState->chunkGroupReadState might be freed, but used next.

		stripeReadState->currentRow += stripeReadState->chunkGroupReadState->rowCount;

```

