### PR TITLE
Remove unnecessary variable

### DIFF
--- a/columnar/src/backend/columnar/columnar_cache.c
+++ b/columnar/src/backend/columnar/columnar_cache.c
@@ -319,12 +319,9 @@ ColumnarAddCacheEntry(uint64 relId, uint64 stripeId, uint64 chunkId,
 	}
 
 	ColumnarCacheEntry *entry = ColumnarFindInCache(relId, stripeId, chunkId, columnId);
-	bool found = false;
 
 	if (entry != NULL)
 	{
-		found = true;
-
 		/* Free up any existing stored data, everything else will be overwritten. */
 		StringInfo str = entry->store;
 		if (str->data)
@@ -347,11 +344,8 @@ ColumnarAddCacheEntry(uint64 relId, uint64 stripeId, uint64 chunkId,
 		entry->creationTime = entry->lastAccessTime = time(NULL);
 		entry->readCount = 0;
 
-		/* Add the entry into the list if it is not already there. */
-		if (!found)
-		{
-			dlist_push_tail(head, &(entry->list_node));
-		}
+		/* Add the entry into the list. */
+		dlist_push_tail(head, &(entry->list_node));
 	}
 
 	uint64 size = ((StringInfo) data)->len;


### PR DESCRIPTION
The `found` variable in `ColumnarAddCacheEntry()` is only used in the `if-else`-branch.  It is true in `if`-branch, and false in the `else`-branch, so that the `dlist_push_tail()` is always executed in the `else`-branch, so the `found` variable is unnecessary.