### PR TITLE
Fix memory leak when executing vectorized quals

### DIFF
--- a/columnar/src/backend/columnar/columnar_customscan.c
+++ b/columnar/src/backend/columnar/columnar_customscan.c
@@ -2380,7 +2380,7 @@ CustomExecScan(ColumnarScanState *columnarScanState,
 				bool *resultQual = 
 					ExecuteVectorizedQual(slot,
 										columnarScanState->vectorization.constructedVectorizedQualList,
-										AND_EXPR);
+										AND_EXPR, econtext);
 
 				memcpy(vectorSlot->keep, resultQual, COLUMNAR_VECTOR_COLUMN_SIZE);
 			}

--- a/columnar/src/include/columnar/vectorization/columnar_vector_execution.h
+++ b/columnar/src/include/columnar/vectorization/columnar_vector_execution.h
@@ -22,6 +22,7 @@ extern List * CreateVectorizedExprList(List *exprList);
 extern List * ConstructVectorizedQualList(TupleTableSlot *slot, List *vectorizedQual);
 extern bool * ExecuteVectorizedQual(TupleTableSlot *slot,
 									List *vectorizedQualList,
-									BoolExprType boolType);
+									BoolExprType boolType,
+									ExprContext *econtext);
 
 #endif


### PR DESCRIPTION
Currently, a `VectorColumn` structure is created when executing vectorized quals for each tuple on the ExecutorState memory context.  However, it will be freed only until execution finishes.  This commit changes the memory context to a tuple memory context.

Here are steps to reproduce:

1. Clone tpch-kit.
   ```bash
   git clone https://github.com/gregrahn/tpch-kit.git
   cd tpch-kit/dbgen
   ```
2. Compile tpch-kit.
    Make sure the following in Makefie:
    ```
    DATABASE = POSTGRESQL
    MACHINE  = LINUX
    WORKLOAD = TPC
    ```
3. Generate data.
    ```bash
    ./dbgen -s 1
    mkdir s1 && for i in $(ls *.tbl); do sed 's/|$//' $i > s1/${i/tbl/csv}; rm $i; done;
    ```
4. Generate load schema and data script.
    ```bash
    cd s1
    echo "CREATE EXTENSION columnar;" > load.sql
    sed 's|);$|) USING columnar;|g' ../dss.ddl >> load.sql
    for csv in $(ls *.csv); do table=$(echo $csv | cut -d. -f1); echo "COPY $table FROM '$PWD/$csv' WITH (FORMAT csv, DELIMITER '|');"; done >> load.sql
    ```
5. Initialize the database and load data.
    ```bash
    initdb -D s1data
    pg_ctl -l logfile -D s1data start
    psql -f load.sql postgres
    ```
6. Test
    1. Start a new connection using `psql`;
    2. use `top` to monitor the memory used by the backend process;
    3. Execute the following query;
         ```sql
         select
           s_name, s_address
         from
           supplier, nation
         where
           s_suppkey in (
             select
               ps_suppkey
             from
               partsupp
             where
               ps_partkey in (
                 select
                   p_partkey
                 from
                   part
                 where
                   p_name like 'khaki%'
               )
               and ps_availqty > (
                 select
                   0.5 * sum(l_quantity)
                 from
                   lineitem
                 where
                   l_partkey = ps_partkey
                   and l_suppkey = ps_suppkey
                   and l_shipdate >= date '1997-01-01'
                   and l_shipdate < date '1997-01-01' + interval '1' year
               )
           )
           and s_nationkey = n_nationkey
           and n_name = 'EGYPT'
         order by
           s_name;
         ```
In the `top` you will see the memory increased and finally cause out of memory.
