### PR TITLE
Do not release the chunk group state if there is data

### DIFF
--- a/columnar/src/backend/columnar/columnar_reader.c
+++ b/columnar/src/backend/columnar/columnar_reader.c
@@ -2154,13 +2154,19 @@ ReadStripeNextVector(StripeReadState *stripeReadState, Datum *columnValues,
 									  rowNumber,
 									  chunkFirstRowNumber))
 		{
-			/* if this chunk group is exhausted, fetch the next one and loop */
-			EndChunkGroupRead(stripeReadState->chunkGroupReadState);
-			stripeReadState->chunkGroupReadState = NULL;
-			stripeReadState->chunkGroupIndex++;
-
+			/*
+			 * if *newVectorSize is non-zero, it means there might be some data in
+			 * chunkGroupReadState->chunkGroupData referenced by VectorColumn.  In
+			 * this case, do NOT release ChunkGroupReadState.
+			 */
 			if (*newVectorSize == 0)
+			{
+				/* if this chunk group is exhausted, fetch the next one and loop */
+				EndChunkGroupRead(stripeReadState->chunkGroupReadState);
+				stripeReadState->chunkGroupReadState = NULL;
+				stripeReadState->chunkGroupIndex++;
 				continue;
+			}
 		}
 		else
 			stripeReadState->currentRow += stripeReadState->chunkGroupReadState->rowCount;

--- a/columnar/src/test/regress/expected/columnar_alter_set_type.out
+++ b/columnar/src/test/regress/expected/columnar_alter_set_type.out
@@ -63,7 +63,7 @@ SELECT columnar.alter_columnar_table_set('test', compression => 'lz4');
 INSERT INTO test VALUES(1);
 VACUUM VERBOSE test;
 INFO:  statistics for "test":
-storage id: 10000000142
+storage id: 10000000143
 total file size: 24576, total data size: 6
 compression rate: 0.83x
 total row count: 1, stripe count: 1, average rows per stripe: 1
@@ -72,7 +72,7 @@ chunk count: 1, containing data for dropped columns: 0, lz4 compressed: 1
 ALTER TABLE test ALTER COLUMN i TYPE int8;
 VACUUM VERBOSE test;
 INFO:  statistics for "test":
-storage id: 10000000143
+storage id: 10000000144
 total file size: 24576, total data size: 10
 compression rate: 0.90x
 total row count: 1, stripe count: 1, average rows per stripe: 1

--- a/columnar/src/test/regress/expected/columnar_query.out
+++ b/columnar/src/test/regress/expected/columnar_query.out
@@ -328,3 +328,31 @@ SELECT count(*) FROM t;
 (1 row)
 
 DROP TABLE t;
+--
+-- [columnar] Bug #244
+--
+CREATE TABLE t(a INT, b TEXT) USING columnar;
+SELECT columnar.alter_columnar_table_set('t', chunk_group_row_limit => '11000');
+ alter_columnar_table_set 
+--------------------------
+ 
+(1 row)
+
+INSERT INTO t SELECT a, md5(b::text) FROM generate_series(0,50000) AS t1(a)
+JOIN LATERAL generate_series(1, 10) AS t2(b) ON (true);
+SELECT b, count(*) FROM t WHERE a > 50 AND b <> '' GROUP BY b;
+                b                 | count 
+----------------------------------+-------
+ 1679091c5a880faf6fb5e6087eb1b2dc | 49950
+ 45c48cce2e2d7fbdea1afc51c7c6ad26 | 49950
+ 8f14e45fceea167a5a36dedd4bea2543 | 49950
+ a87ff679a2f3e71d9181a67b7542122c | 49950
+ c4ca4238a0b923820dcc509a6f75849b | 49950
+ c81e728d9d4c2f636f067f89cc14862c | 49950
+ c9f0f895fb98ab9159f51fd0297e236d | 49950
+ d3d9446802a44259755d38e6d163e820 | 49950
+ e4da3b7fbbce2345d7772b0674a318d5 | 49950
+ eccbc87e4b5ce2fe28308fd9f2a7baf3 | 49950
+(10 rows)
+
+DROP TABLE t;

--- a/columnar/src/test/regress/sql/columnar_query.sql
+++ b/columnar/src/test/regress/sql/columnar_query.sql
@@ -175,3 +175,19 @@ INSERT INTO t SELECT a FROM generate_series(0,50000) AS a;
 SELECT count(*) FROM t;
 
 DROP TABLE t;
+
+
+--
+-- [columnar] Bug #244
+--
+
+CREATE TABLE t(a INT, b TEXT) USING columnar;
+
+SELECT columnar.alter_columnar_table_set('t', chunk_group_row_limit => '11000');
+
+INSERT INTO t SELECT a, md5(b::text) FROM generate_series(0,50000) AS t1(a)
+JOIN LATERAL generate_series(1, 10) AS t2(b) ON (true);
+
+SELECT b, count(*) FROM t WHERE a > 50 AND b <> '' GROUP BY b;
+
+DROP TABLE t;


### PR DESCRIPTION
When the chunk group row limit is bigger than `COLUMNAR_VECTOR_COLUMN_SIZE`, there might be some data referenced by VectorColumn, so if there is data read by ReadChunkGroupNextVector(), do not release ChunkGroupReadState. See #244.