### PR TITLE
Remove redundant code in ColumnarStorageUpdateIfNeeded

### DIFF
--- a/columnar/src/backend/columnar/columnar_metadata.c
+++ b/columnar/src/backend/columnar/columnar_metadata.c
@@ -2544,18 +2544,9 @@ ColumnarStorageUpdateIfNeeded(Relation rel, bool isUpgrade)
 	}
 
 	/*
-	 * RelationGetSmgr was added in 15, but only backported to 13.10 and 14.07
-	 * leaving other versions requiring something like this.
+	 * ColumnarStorageIsCurrent() has already verified the state of
+	 * rel->rd_smgr and is attempting to open it.
 	 */
-	if (unlikely(rel->rd_smgr == NULL))
-	{
-	#if PG_VERSION_NUM >= PG_VERSION_16
-		smgrsetowner(&(rel->rd_smgr), smgropen(rel->rd_locator, rel->rd_backend));
-	#else
-		smgrsetowner(&(rel->rd_smgr), smgropen(rel->rd_node, rel->rd_backend));
-	#endif
-	}
-
 	BlockNumber nblocks = smgrnblocks(rel->rd_smgr, MAIN_FORKNUM);
 	if (nblocks < 2)
 	{

--- a/columnar/src/backend/columnar/columnar_storage.c
+++ b/columnar/src/backend/columnar/columnar_storage.c
@@ -365,12 +365,16 @@ ColumnarStorageGetReservedOffset(Relation rel, bool force)
 
 
 /*
- * ColumnarStorageIsCurrent - return true if metapage exists and is not
+ * ColumnarStorageIsCurrent - return true if metapage exists and is
  * the current version.
  */
 bool
 ColumnarStorageIsCurrent(Relation rel)
 {
+	/*
+	 * RelationGetSmgr was added in 15, but only backported to 13.10 and 14.07
+	 * leaving other versions requiring something like this.
+	 */
 	if (unlikely(rel->rd_smgr == NULL))
 	{
 #if PG_VERSION_NUM >= PG_VERSION_16


### PR DESCRIPTION
The ColumnarStorageIsCurrent will attempt to open SMGR when it doesn't open, so ColumnarStorageUpdateIfNeeded is not required to check SMGR.

OTOH, ColumnarStorageIsCurrent only returns true if metapage exists and is the current version, so fix the comment.