### PR TITLE
[columnar] turn off caching when building an index

### DIFF
--- a/columnar/src/test/regress/expected/columnar_alter_set_type.out
+++ b/columnar/src/test/regress/expected/columnar_alter_set_type.out
@@ -63,7 +63,7 @@ SELECT columnar.alter_columnar_table_set('test', compression => 'lz4');
 INSERT INTO test VALUES(1);
 VACUUM VERBOSE test;
 INFO:  statistics for "test":
-storage id: 10000000142
+storage id: 10000000143
 total file size: 24576, total data size: 6
 compression rate: 0.83x
 total row count: 1, stripe count: 1, average rows per stripe: 1
@@ -72,7 +72,7 @@ chunk count: 1, containing data for dropped columns: 0, lz4 compressed: 1
 ALTER TABLE test ALTER COLUMN i TYPE int8;
 VACUUM VERBOSE test;
 INFO:  statistics for "test":
-storage id: 10000000143
+storage id: 10000000144
 total file size: 24576, total data size: 10
 compression rate: 0.90x
 total row count: 1, stripe count: 1, average rows per stripe: 1

--- a/columnar/src/test/regress/expected/columnar_indexes.out
+++ b/columnar/src/test/regress/expected/columnar_indexes.out
@@ -796,5 +796,19 @@ BEGIN;
 (1 row)
 
 ROLLBACK;
+CREATE TABLE test_cache (
+  i INT, t TEXT
+) USING columnar;
+INSERT INTO test_cache SELECT generate_series(1, 100, 1) AS i, generate_series(1, 100, 1)::TEXT AS t;
+SET columnar.enable_column_cache = 't';
+CREATE INDEX ON test_cache (i);
+-- should be true
+SHOW columnar.enable_column_cache;
+ columnar.enable_column_cache 
+------------------------------
+ on
+(1 row)
+
+DROP TABLE test_cache;
 SET client_min_messages TO WARNING;
 DROP SCHEMA columnar_indexes CASCADE;

--- a/columnar/src/test/regress/expected/columnar_vacuum.out
+++ b/columnar/src/test/regress/expected/columnar_vacuum.out
@@ -472,3 +472,20 @@ SELECT COUNT(*) = 4 FROM columnar.stripe WHERE storage_id = :t_oid;
 (1 row)
 
 DROP TABLE t;
+CREATE TABLE cache_test (i INT) USING columnar;
+INSERT INTO cache_test SELECT generate_series(1, 100, 1);
+SET columnar.enable_column_cache = 't';
+SELECT columnar.vacuum('cache_test');
+ vacuum 
+--------
+      0
+(1 row)
+
+-- should be true
+SHOW columnar.enable_column_cache;
+ columnar.enable_column_cache 
+------------------------------
+ on
+(1 row)
+
+DROP TABLE cache_test;

--- a/columnar/src/test/regress/expected/columnar_vacuum_udf.out
+++ b/columnar/src/test/regress/expected/columnar_vacuum_udf.out
@@ -366,3 +366,23 @@ SELECT count(i1), count(i2), count(i3), count(i4) FROM t1;
 (1 row)
 
 DROP TABLE t1;
+CREATE TABLE cache_test (i INT) USING columnar;
+INSERT INTO cache_test SELECT generate_series(1, 100, 1);
+SET columnar.enable_column_cache = 't';
+VACUUM cache_test;
+-- should be true
+SHOW columnar.enable_column_cache;
+ columnar.enable_column_cache 
+------------------------------
+ on
+(1 row)
+
+ANALYZE cache_test;
+-- should be true
+SHOW columnar.enable_column_cache;
+ columnar.enable_column_cache 
+------------------------------
+ on
+(1 row)
+
+DROP TABLE cache_test;

--- a/columnar/src/test/regress/expected/columnar_vacuum_udf_1.out
+++ b/columnar/src/test/regress/expected/columnar_vacuum_udf_1.out
@@ -366,3 +366,23 @@ SELECT count(i1), count(i2), count(i3), count(i4) FROM t1;
 (1 row)
 
 DROP TABLE t1;
+CREATE TABLE cache_test (i INT) USING columnar;
+INSERT INTO cache_test SELECT generate_series(1, 100, 1);
+SET columnar.enable_column_cache = 't';
+VACUUM cache_test;
+-- should be true
+SHOW columnar.enable_column_cache;
+ columnar.enable_column_cache 
+------------------------------
+ on
+(1 row)
+
+ANALYZE cache_test;
+-- should be true
+SHOW columnar.enable_column_cache;
+ columnar.enable_column_cache 
+------------------------------
+ on
+(1 row)
+
+DROP TABLE cache_test;

--- a/columnar/src/test/regress/sql/columnar_indexes.sql
+++ b/columnar/src/test/regress/sql/columnar_indexes.sql
@@ -642,6 +642,18 @@ BEGIN;
   SELECT COUNT(*) FROM circles_and_stuff; -- should return 1
 ROLLBACK;
 
+CREATE TABLE test_cache (
+  i INT, t TEXT
+) USING columnar;
+INSERT INTO test_cache SELECT generate_series(1, 100, 1) AS i, generate_series(1, 100, 1)::TEXT AS t;
+
+SET columnar.enable_column_cache = 't';
+
+CREATE INDEX ON test_cache (i);
+-- should be true
+SHOW columnar.enable_column_cache;
+
+DROP TABLE test_cache;
 
 SET client_min_messages TO WARNING;
 DROP SCHEMA columnar_indexes CASCADE;

--- a/columnar/src/test/regress/sql/columnar_vacuum.sql
+++ b/columnar/src/test/regress/sql/columnar_vacuum.sql
@@ -269,3 +269,14 @@ VACUUM t;
 SELECT COUNT(*) = 4 FROM columnar.stripe WHERE storage_id = :t_oid;
 
 DROP TABLE t;
+
+CREATE TABLE cache_test (i INT) USING columnar;
+INSERT INTO cache_test SELECT generate_series(1, 100, 1);
+
+SET columnar.enable_column_cache = 't';
+SELECT columnar.vacuum('cache_test');
+
+-- should be true
+SHOW columnar.enable_column_cache;
+
+DROP TABLE cache_test;

--- a/columnar/src/test/regress/sql/columnar_vacuum_udf.sql
+++ b/columnar/src/test/regress/sql/columnar_vacuum_udf.sql
@@ -89,3 +89,19 @@ SELECT columnar.vacuum('t1');
 SELECT count(i1), count(i2), count(i3), count(i4) FROM t1;
 
 DROP TABLE t1;
+
+CREATE TABLE cache_test (i INT) USING columnar;
+INSERT INTO cache_test SELECT generate_series(1, 100, 1);
+
+SET columnar.enable_column_cache = 't';
+VACUUM cache_test;
+
+-- should be true
+SHOW columnar.enable_column_cache;
+
+ANALYZE cache_test;
+
+-- should be true
+SHOW columnar.enable_column_cache;
+
+DROP TABLE cache_test;


### PR DESCRIPTION
when an index is being built, we should disable the column cache for the duration to stop multiple cache evictions on large tables.