### PR TITLE
[columnar] fix storage id for alter set type

### DIFF
--- a/columnar/src/test/regress/expected/columnar_alter_set_type.out
+++ b/columnar/src/test/regress/expected/columnar_alter_set_type.out
@@ -63,7 +63,7 @@ SELECT columnar.alter_columnar_table_set('test', compression => 'lz4');
 INSERT INTO test VALUES(1);
 VACUUM VERBOSE test;
 INFO:  statistics for "test":
-storage id: 10000000143
+storage id: 10000000144
 total file size: 24576, total data size: 6
 compression rate: 0.83x
 total row count: 1, stripe count: 1, average rows per stripe: 1
@@ -72,7 +72,7 @@ chunk count: 1, containing data for dropped columns: 0, lz4 compressed: 1
 ALTER TABLE test ALTER COLUMN i TYPE int8;
 VACUUM VERBOSE test;
 INFO:  statistics for "test":
-storage id: 10000000144
+storage id: 10000000145
 total file size: 24576, total data size: 10
 compression rate: 0.90x
 total row count: 1, stripe count: 1, average rows per stripe: 1


### PR DESCRIPTION
fixes tests that inadvertently got broken during a merge.