### PR TITLE
Fix memory leak when updating chunk skip node

### DIFF
--- a/columnar/src/backend/columnar/columnar_writer.c
+++ b/columnar/src/backend/columnar/columnar_writer.c
@@ -759,6 +759,9 @@ UpdateChunkSkipNodeMinMax(ColumnChunkSkipNode *chunkSkipNode, Datum columnValue,
 
 		if (minimumComparison < 0)
 		{
+			if (!columnTypeByValue)
+				pfree(DatumGetPointer(previousMinimum));
+
 			currentMinimum = DatumCopy(columnValue, columnTypeByValue, columnTypeLength);
 		}
 		else
@@ -768,6 +771,9 @@ UpdateChunkSkipNodeMinMax(ColumnChunkSkipNode *chunkSkipNode, Datum columnValue,
 
 		if (maximumComparison > 0)
 		{
+			if (!columnTypeByValue)
+				pfree(DatumGetPointer(previousMaximum));
+
 			currentMaximum = DatumCopy(columnValue, columnTypeByValue, columnTypeLength);
 		}
 		else


### PR DESCRIPTION
When UpdateChunkSkipNodeMinMax() is executed, it may allocate memory for non-fixed size data types. If the minimum or maximum value changes, the previous value will be overwritten, resulting in a memory leak.

For example:

```sql
CREATE TABLE t (id serial, data text) USING columnar;
INSERT INTO t SELECT 1, repeat('a', 255000000);
INSERT INTO t SELECT 2, repeat('b', 255000000);
INSERT INTO t SELECT 3, repeat('c', 255000000);
INSERT INTO t SELECT 4, repeat('d', 255000000);
INSERT INTO t SELECT 5, repeat('e', 255000000);
INSERT INTO t SELECT 6, repeat('f', 255000000);
```

Patched reduced memory usage from 3.6G to 3.0G (top's RES) when running `VACUUM t`.