### PR TITLE
Avoid calling the get_typlen multiple times

### DIFF
--- a/columnar/src/backend/columnar/columnar_reader.c
+++ b/columnar/src/backend/columnar/columnar_reader.c
@@ -2239,10 +2239,10 @@ ReadChunkGroupNextVector(ChunkGroupReadState *chunkGroupReadState, Datum *column
 
 
 				/* 
-				 * For data types which have len less or equal 8 we can
+				 * For data types which have len less or equal sizeof(Datum) we can
 				 * use `store_att_byval` function.
 				 */
-				if (vectorColumn->columnTypeLen <= 8)
+				if (vectorColumn->columnTypeLen <= sizeof(Datum))
 				{
 					store_att_byval(writeColumnRowPosition,
 									chunkGroupData->valueArray[columnIndex][rowIndex],

--- a/columnar/src/backend/columnar/vectorization/columnar_vector_types.c
+++ b/columnar/src/backend/columnar/vectorization/columnar_vector_types.c
@@ -65,7 +65,7 @@ CreateVectorTupleTableSlot(TupleDesc tupleDesc)
 		int16 columnTypeLen = get_typlen(columnTypeOid);
 
 		int16 vectorColumnTypeLen = 
-			columnTypeLen == -1 ?  sizeof(Datum) : get_typlen(columnTypeOid);
+			columnTypeLen == -1 ?  sizeof(Datum) : columnTypeLen;
 
 		/* 
 		 * We consider that type is passed by val also for cases where we have 


### PR DESCRIPTION
This commit also changes the column type length judgment in `ReadChunkGroupNextVector()`.  According to Postgres code, not all platforms have `sizeof(Datum) == 8` [1], so it might be better to use `sizeof(Datum)` instead of the magic number 8.

[1] https://github.com/postgres/postgres/blob/master/src/include/postgres.h#L58
