### PR TITLE
[columnar] Fix for case sensitive schema names (#264)

### DIFF
--- a/columnar/src/backend/columnar/columnar.control
+++ b/columnar/src/backend/columnar/columnar.control
@@ -1,4 +1,4 @@
 comment = 'Hydra Columnar extension'
-default_version = '11.1-11'
+default_version = '11.1-12'
 module_pathname = '$libdir/columnar'
 relocatable = false

--- a/columnar/src/backend/columnar/sql/columnar--11.1-11--11.1-12.sql
+++ b/columnar/src/backend/columnar/sql/columnar--11.1-11--11.1-12.sql
@@ -1,0 +1,1 @@
+#include "udfs/alter_table_set_access_method/11.1-12.sql"

--- a/columnar/src/backend/columnar/sql/udfs/alter_table_set_access_method/11.1-12.sql
+++ b/columnar/src/backend/columnar/sql/udfs/alter_table_set_access_method/11.1-12.sql
@@ -58,7 +58,7 @@ BEGIN
         RETURN 0;
     END IF;
 
-    -- Case sensitivity
+    -- Case senstivitiy
 
     SELECT EXISTS (SELECT regexp_matches(tbl_name,'[A-Z]')) INTO is_case_sensitive;
 

--- a/columnar/src/test/regress/expected/columnar_alter_table_set_access_method.out
+++ b/columnar/src/test/regress/expected/columnar_alter_table_set_access_method.out
@@ -545,3 +545,121 @@ ORDER BY conname;
 (3 rows)
 
 DROP TABLE "tBl";
+-- 11. Check case sensitivity and schema sensitivity
+CREATE SCHEMA "tEST";
+CREATE TABLE "tEST"."tBl" (
+  c1 CIRCLE,
+  "C2" TEXT,
+  i int4[],
+  p point,
+  a int,
+  EXCLUDE USING gist
+    (c1 WITH &&, ("C2"::circle) WITH &&)
+    WHERE (circle_center(c1) <> '(0,0)'),
+  EXCLUDE USING btree
+    (a WITH =)
+	INCLUDE(p)
+	WHERE ("C2" < 'astring')
+);
+CREATE INDEX "TBL_GIN" ON "tEST"."tBl" USING gin (i);
+CREATE INDEX tbl_gist ON "tEST"."tBl" USING gist(p);
+CREATE INDEX tbl_brin ON "tEST"."tBl" USING brin (a) WITH (pages_per_range = 1);
+CREATE INDEX tbl_hash ON "tEST"."tBl" USING hash ("C2");
+ALTER TABLE "tEST"."tBl" ADD CONSTRAINT tbl_unique UNIQUE ("C2");
+CREATE UNIQUE INDEX tbl_btree ON "tEST"."tBl" USING btree (a);
+ALTER TABLE "tEST"."tBl" ADD CONSTRAINT tbl_pkey PRIMARY KEY USING INDEX tbl_btree;
+NOTICE:  ALTER TABLE / ADD CONSTRAINT USING INDEX will rename index "tbl_btree" to "tbl_pkey"
+SELECT indexname, indexdef FROM pg_indexes
+WHERE tablename = 'tBl'
+ORDER BY indexname;
+   indexname    |                                                          indexdef                                                           
+----------------+-----------------------------------------------------------------------------------------------------------------------------
+ TBL_GIN        | CREATE INDEX "TBL_GIN" ON "tEST"."tBl" USING gin (i)
+ tBl_a_p_excl   | CREATE INDEX "tBl_a_p_excl" ON "tEST"."tBl" USING btree (a) INCLUDE (p) WHERE ("C2" < 'astring'::text)
+ tBl_c1_C2_excl | CREATE INDEX "tBl_c1_C2_excl" ON "tEST"."tBl" USING gist (c1, (("C2")::circle)) WHERE (circle_center(c1) <> '(0,0)'::point)
+ tbl_brin       | CREATE INDEX tbl_brin ON "tEST"."tBl" USING brin (a) WITH (pages_per_range='1')
+ tbl_gist       | CREATE INDEX tbl_gist ON "tEST"."tBl" USING gist (p)
+ tbl_hash       | CREATE INDEX tbl_hash ON "tEST"."tBl" USING hash ("C2")
+ tbl_pkey       | CREATE UNIQUE INDEX tbl_pkey ON "tEST"."tBl" USING btree (a)
+ tbl_unique     | CREATE UNIQUE INDEX tbl_unique ON "tEST"."tBl" USING btree ("C2")
+(8 rows)
+
+SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conrelid = '"tEST"."tBl"'::regclass;
+                                          pg_get_constraintdef                                           
+---------------------------------------------------------------------------------------------------------
+ EXCLUDE USING gist (c1 WITH &&, (("C2")::circle) WITH &&) WHERE ((circle_center(c1) <> '(0,0)'::point))
+ EXCLUDE USING btree (a WITH =) INCLUDE (p) WHERE (("C2" < 'astring'::text))
+ UNIQUE ("C2")
+ PRIMARY KEY (a)
+(4 rows)
+
+SELECT columnar.alter_table_set_access_method('"tEST"."tBl"', 'columnar');
+WARNING:  Index `CREATE INDEX tbl_brin ON "tEST"."tBl" USING brin (a) WITH (pages_per_range='1')` cannot be created.
+ alter_table_set_access_method 
+-------------------------------
+ t
+(1 row)
+
+SELECT COUNT(1) FROM pg_class WHERE relname = 'tBl' AND relam = (SELECT oid FROM pg_am WHERE amname = 'columnar');
+ count 
+-------
+     1
+(1 row)
+
+SELECT indexname FROM pg_indexes WHERE tablename = 'tBl' ORDER BY indexname;
+  indexname   
+--------------
+ TBL_GIN
+ tbl_a_p_excl
+ tbl_gist
+ tbl_hash
+ tbl_pkey
+ tbl_unique
+(6 rows)
+
+SELECT conname FROM pg_constraint
+WHERE conrelid = '"tEST"."tBl"'::regclass
+ORDER BY conname;
+   conname    
+--------------
+ tbl_a_p_excl
+ tbl_pkey
+ tbl_unique
+(3 rows)
+
+-- Convert back to 'heap'
+SELECT columnar.alter_table_set_access_method('"tEST"."tBl"', 'heap');
+ alter_table_set_access_method 
+-------------------------------
+ t
+(1 row)
+
+SELECT COUNT(1) FROM pg_class WHERE relname = 'tBl' AND relam = (SELECT oid FROM pg_am WHERE amname = 'heap');
+ count 
+-------
+     1
+(1 row)
+
+SELECT indexname FROM pg_indexes WHERE tablename = 'tBl' ORDER BY indexname;
+  indexname   
+--------------
+ TBL_GIN
+ tbl_a_p_excl
+ tbl_gist
+ tbl_hash
+ tbl_pkey
+ tbl_unique
+(6 rows)
+
+SELECT conname FROM pg_constraint
+WHERE conrelid = '"tEST"."tBl"'::regclass
+ORDER BY conname;
+   conname    
+--------------
+ tbl_a_p_excl
+ tbl_pkey
+ tbl_unique
+(3 rows)
+
+DROP TABLE "tEST"."tBl";
+DROP SCHEMA "tEST";


### PR DESCRIPTION
* We should be able to convert case sensitive schema name and table names. For case sensitive names function argument for `alter_table_set_access_method` should be like "Schema"."Table".

<!--
Thanks for opening a pull request to Hydra! We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Please make sure your code changes are covered with tests.
- If your change affects functionality, please include an entry for your PR in CHANGELOG.md
- In the case of new features or big changes, please open a docs PR for the feature at our docs repo:
  https://github.com/hydradatabase/docs

Feel free to ping committers for the review!
-->

<!-- Include an overview here -->

### What's changed?

<!--
Describe in detail what you've changed.

A code blurb is best. Changes to features should include an example that is executable by a new user.
If changing documentation, a link to a preview of the page is great.
 -->
