### PR TITLE
Fix overflow in int16 variable

### DIFF
--- a/columnar/src/backend/columnar/columnar_planner_hook.c
+++ b/columnar/src/backend/columnar/columnar_planner_hook.c
@@ -408,11 +408,12 @@ static bool
 IsCreateTableAs(const char *query)
 {
 	char *c, *t, *a;
-	char *haystack = (char *) palloc(strlen(query) + 1);
-	int16 i;
+	size_t query_len = strlen(query);
+	char *haystack = (char *) palloc(query_len + 1);
+	int32 i;
 
 	/* Create a lower case copy of the string. */
-	for (i = 0; i < strlen(query); i++)
+	for (i = 0; i < query_len; i++)
 	{
 		haystack[i] = tolower(query[i]);
 	}


### PR DESCRIPTION
### What's wrong

[In function IsCreateTableAs in columnar_planner_hook.c](https://github.com/hydradatabase/hydra/blob/47354c2b576b0092786a5578049d998bd7c2287f/columnar/src/backend/columnar/columnar_planner_hook.c#L412) there is variable `int16 i` uses as iteration variable.
It works fine on small requests, but when there is large script it causes overflow with consequences in such way:

1. `i = INT16_MAX` (script is large)
2. `++i = INT16_MIN` (overflow)
3. for loop condition is not met - loop ends
4. `i == -32768`
5. `haystack[i] = '\0'` == `haystack[-32768] = '\0';` - we overwrite some memory address

Steps to reproduce:

1. Create and install (not `CREATE EXTENSION` yet) stub extension with large sql file. I.e. 10000 lines of `select 1;`
2. Run DB and PSQL (next execute in PSQL)
3. Execute `CREATE EXTENSION columnar;` (just create extension)
4. Place breakpoint after for-loop end ([columnar/columnar_planner_hook.c:420](https://github.com/hydradatabase/hydra/blob/47354c2b576b0092786a5578049d998bd7c2287f/columnar/src/backend/columnar/columnar_planner_hook.c#L420))
5. Attach with debugger (I am using VS Code)
6. Execute `CREATE EXTENSION sample_extension` (extension created at 1 step)

After you run this you will see, that execution stopped and `i = -32768`.

![Снимок экрана от 2024-10-07 18-45-31](https://github.com/user-attachments/assets/bf0a9547-b98b-4044-8cac-b644d51f0719)

Every time consequences will be different. But in my case i got some warnings from memory allocator and then backend has crashed. Logs included:

```log
2024-10-07 17:23:45.372 MSK [642515] WARNING:  problem in alloc set PortalContext: req size > alloc size for chunk 0x315be40 in block 0x315ac20
TRAP: failed Assert("!HdrMaskIsExternal(chunk->hdrmask) || HdrMaskCheckMagic(chunk->hdrmask)"), File: "../../../../src/include/utils/memutils_memorychunk.h", Line: 195, PID: 642515
postgres: postgres postgres 127.0.0.1(59920) CREATE EXTENSION(ExceptionalCondition+0x9e)[0xb96a77]
postgres: postgres postgres 127.0.0.1(59920) CREATE EXTENSION[0xbc7750]
postgres: postgres postgres 127.0.0.1(59920) CREATE EXTENSION(AllocSetCheck+0x19d)[0xbc9542]
postgres: postgres postgres 127.0.0.1(59920) CREATE EXTENSION(AllocSetDelete+0x54)[0xbc7ed3]
postgres: postgres postgres 127.0.0.1(59920) CREATE EXTENSION(MemoryContextDelete+0xe7)[0xbd2cd3]
postgres: postgres postgres 127.0.0.1(59920) CREATE EXTENSION(PortalDrop+0x32f)[0xbd5d52]
postgres: postgres postgres 127.0.0.1(59920) CREATE EXTENSION[0x9d4a64]
postgres: postgres postgres 127.0.0.1(59920) CREATE EXTENSION(PostgresMain+0x751)[0x9d92b8]
postgres: postgres postgres 127.0.0.1(59920) CREATE EXTENSION[0x90f949]
postgres: postgres postgres 127.0.0.1(59920) CREATE EXTENSION[0x90f2e2]
postgres: postgres postgres 127.0.0.1(59920) CREATE EXTENSION[0x90bb26]
postgres: postgres postgres 127.0.0.1(59920) CREATE EXTENSION(PostmasterMain+0x1262)[0x90b4f8]
postgres: postgres postgres 127.0.0.1(59920) CREATE EXTENSION[0x7d48cc]
/lib/x86_64-linux-gnu/libc.so.6(+0x2a1ca)[0x7ba77202a1ca]
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0x8b)[0x7ba77202a28b]
postgres: postgres postgres 127.0.0.1(59920) CREATE EXTENSION(_start+0x25)[0x4a5245]
2024-10-07 17:23:45.652 MSK [642503] LOG:  server process (PID 642515) was terminated by signal 6: Аварийный останов
2024-10-07 17:23:45.652 MSK [642503] DETAIL:  Failed process was running: create extension sample_extension cascade;
2024-10-07 17:23:45.652 MSK [642503] LOG:  terminating any other active server processes
2024-10-07 17:23:45.654 MSK [643391] FATAL:  the database system is in recovery mode
```

### What's changed

I have fixed this by changing type from `int16` to `int32`.

Also, I have saved `strlen(query)` value in separate variable, this should increase performance.