### PR TITLE
cache: fix pfree valueBuffer

### DIFF
--- a/columnar/src/backend/columnar/columnar_reader.c
+++ b/columnar/src/backend/columnar/columnar_reader.c
@@ -1955,8 +1955,15 @@ DeserializeChunkData(StripeBuffers *stripeBuffers, uint64 chunkIndex,
 								  attributeForm->attlen, attributeForm->attalign,
 								  chunkData->valueArray[columnIndex]);
 
-			/* store current chunk's data buffer to be freed at next chunk read */
-			chunkData->valueBufferArray[columnIndex] = valueBuffer;
+			if(shouldCache)
+			{
+				/* store current chunk's data buffer to be freed at next chunk read */
+				chunkData->valueBufferArray[columnIndex] = NULL;
+			}
+			else
+			{
+				chunkData->valueBufferArray[columnIndex] = valueBuffer;
+			}
 		}
 		else if (columnAdded)
 		{


### PR DESCRIPTION
Hello.
This MR fixes an issue with a cache. The cache entry contains already freed memory.

###  SQL code to reproduce
[broken_cache.txt](https://github.com/user-attachments/files/18188536/broken_cache.txt)

Steps:
1. create a table
2. convert it to columnar
3. enable caching
4. try convert to heap...
5. get an error:
```
pfree called with invalid pointer 0x5414c18 (header 0x0000000000000000) 
```

### Description
Currently an error 
```c
pfree called with invalid pointer 0x5414c18 (header 0x0000000000000000) 
```
occurs  when cache is full and we try to free up space by 10%.
We call in the `EvictCache`
```c
pfree(str->data);
```
but `str->data` contains a garbage, so `BogusFree` with an `ERROR` is executed (see **Path to BogusFree** chapter below)

The reason to a garbage is the following.

A `valueBuffer (StringInfo)` is added to a cache in the `ColumnarAddCacheEntry` Also it's added to `chunkData->valueBufferArray`

```c
static ChunkData *
DeserializeChunkData(StripeBuffers *stripeBuffers, uint64 chunkIndex,
					 uint32 rowCount, TupleDesc tupleDescriptor,
					 List *projectedColumnList, StripeReadState *state, uint64 stripeId)
{
...
				if (shouldCache)
				{
					ColumnarAddCacheEntry(state->relation->rd_id, stripeId, chunkIndex, columnIndex, valueBuffer);
					MemoryContextSwitchTo(oldMemoryContext);
				}
			}
....
			chunkData->valueBufferArray[columnIndex] = valueBuffer;
}
```

In the function `FreeChunkBufferValueArray` `valueBuffer` will be freed

```c
void FreeChunkBufferValueArray(ChunkData *chunkData)
{
....
			pfree(chunkData->valueBufferArray[columnIndex]->data);
			pfree(chunkData->valueBufferArray[columnIndex]);
...
}
```

and also `EvictCache` tries to freed it as our cache is full `if (totalAllocationLength >= (columnar_page_cache_size * 1024 * 1024))`

```c
static void
EvictCache(uint64 size)
{
....
				StringInfo str = entry->store;
				if (str->data) {
					pfree(str->data);
				}

				pfree(str);
}
```
And we got an ERROR.

To fix this, we mustn't add `valueBufferArray` to `chunkData->valueBufferArray` when previously have added it to a cache

```c
static ChunkData *
DeserializeChunkData(StripeBuffers *stripeBuffers, uint64 chunkIndex,
					 uint32 rowCount, TupleDesc tupleDescriptor,
					 List *projectedColumnList, StripeReadState *state, uint64 stripeId)
{
...
			if(shouldCache) {
				/* store current chunk's data buffer to be freed at next chunk read */
				chunkData->valueBufferArray[columnIndex] = NULL;
			}
			else {
				chunkData->valueBufferArray[columnIndex] = valueBuffer;
			}
```

###  Path to BogusFree
```c
src/backend/columnar/columnar_cache.c
void
ColumnarAddCacheEntry(uint64 relId, uint64 stripeId, uint64 chunkId,
 uint32 columnId, void *data)
{
| 363/* If we are over our cache allocation, clear until we are at 90%. */     │ 
│364 if (totalAllocationLength >= (columnar_page_cache_size * 1024 * 1024))     │ 
│365 {          │ 
>│366 EvictCache((columnar_page_cache_size * 1024 * 1024 * .1) +      │ 
│367   (totalAllocationLength - (columnar_page_cache_size * 1024 * 1024)));   │ 
│368}

static void
EvictCache(uint64 size)
{
				StringInfo str = entry->store;
				if (str->data) {
					pfree(str->data);
				}

src/backend/utils/mmgr/mcxt.c
/*
 * pfree
 *		Release an allocated chunk.
 */
void
pfree(void *pointer)
{
...
	MCXT_METHOD(pointer, free_p) (pointer); // calls BogusFree as pointer is broken
.....
}


src/backend/utils/mmgr/mcxt.c
  /*
 * Support routines to trap use of invalid memory context method IDs
 * (from calling pfree or the like on a bogus pointer).  As a possible
 * aid in debugging, we report the header word along with the pointer
 * address (if we got here, there must be an accessible header word).
 */
static void
BogusFree(void *pointer)
{
	elog(ERROR, "pfree called with invalid pointer %p (header 0x%016llx)",
		 pointer, (unsigned long long) GetMemoryChunkHeader(pointer));
}

```

### Backtrace:
```bash
BogusFree(void * pointer) (/build/src/backend/utils/mmgr/mcxt.c:239)
pfree(void * pointer) (/build/src/backend/utils/mmgr/mcxt.c:1467)
pg_columnar.so!FreeChunkBufferValueArray(ChunkData * chunkData) (/build/contrib/hydra/src/backend/columnar/columnar_reader.c:1240)
pg_columnar.so!EndChunkGroupRead(ChunkGroupReadState * chunkGroupReadState) (/build/contrib/hydra/src/backend/columnar/columnar_reader.c:1053)
pg_columnar.so!ReadStripeNextRow(StripeReadState * stripeReadState, Datum * columnValues, _Bool * columnNulls, uint64 stripeFirstRowNumber, Snapshot snapshot, uint64 stripeId) (/build/contrib/hydra/src/backend/columnar/columnar_reader.c:993)
pg_columnar.so!ColumnarReadNextRow(ColumnarReadState * readState, Datum * columnValues, _Bool * columnNulls, uint64 * rowNumber) (/build/contrib/hydra/src/backend/columnar/columnar_reader.c:356)
pg_columnar.so!columnar_getnextslot(TableScanDesc sscan, ScanDirection direction, TupleTableSlot * slot) (/build/contrib/hydra/src/backend/columnar/columnar_tableam.c:403)
pg_columnar.so!table_scan_getnextslot(TableScanDesc sscan, ScanDirection direction, TupleTableSlot * slot) (/build/src/include/access/tableam.h:1066)
pg_columnar.so!ColumnarScanNext(ColumnarScanState * columnarScanState) (/build/contrib/hydra/src/backend/columnar/columnar_customscan.c:2474)
pg_columnar.so!ExecScanFetch(ScanState * node, ExecScanAccessMtd accessMtd, ExecScanRecheckMtd recheckMtd) (/build/contrib/hydra/src/backend/columnar/columnar_customscan.c:2187)
pg_columnar.so!CustomExecScan(ColumnarScanState * columnarScanState, ExecScanAccessMtd accessMtd, ExecScanRecheckMtd recheckMtd) (/build/contrib/hydra/src/backend/columnar/columnar_customscan.c:2217)
pg_columnar.so!ColumnarScan_ExecCustomScan(CustomScanState * node) (/build/contrib/hydra/src/backend/columnar/columnar_customscan.c:2506)
ExecCustomScan(PlanState * pstate) (/build/src/backend/executor/nodeCustom.c:124)
ExecProcNode(PlanState * node) (/build/src/include/executor/executor.h:273)
ExecModifyTable(PlanState * pstate) (/build/src/backend/executor/nodeModifyTable.c:3730)
ExecProcNodeFirst(PlanState * node) (/build/src/backend/executor/execProcnode.c:464)
ExecProcNode(PlanState * node) (/build/src/include/executor/executor.h:273)
ExecutePlan(EState * estate, PlanState * planstate, _Bool use_parallel_mode, CmdType operation, _Bool sendTuples, uint64 numberTuples, ScanDirection direction, DestReceiver * dest, _Bool execute_once) (/build/src/backend/executor/execMain.c:1678)
standard_ExecutorRun(QueryDesc * queryDesc, ScanDirection direction, uint64 count, _Bool execute_once) (/build/src/backend/executor/execMain.c:367)
ExecutorRun(QueryDesc * queryDesc, ScanDirection direction, uint64 count, _Bool execute_once) (/build/src/backend/executor/execMain.c:311)
_SPI_pquery(QueryDesc * queryDesc, _Bool fire_triggers, uint64 tcount) (/build/src/backend/executor/spi.c:2929)
_SPI_execute_plan(SPIPlanPtr plan, const SPIExecuteOptions * options, Snapshot snapshot, Snapshot crosscheck_snapshot, _Bool fire_triggers) (/build/src/backend/executor/spi.c:2699)
SPI_execute_extended(const char * src, const SPIExecuteOptions * options) (/build/src/backend/executor/spi.c:663)
plpgsql.so!exec_stmt_dynexecute(PLpgSQL_execstate * estate, PLpgSQL_stmt_dynexecute * stmt) (/build/src/pl/plpgsql/src/pl_exec.c:4636)
plpgsql.so!exec_stmts(PLpgSQL_execstate * estate, List * stmts) (/build/src/pl/plpgsql/src/pl_exec.c:2127)
plpgsql.so!exec_stmt_block(PLpgSQL_execstate * estate, PLpgSQL_stmt_block * block) (/build/src/pl/plpgsql/src/pl_exec.c:1971)
plpgsql.so!exec_toplevel_block(PLpgSQL_execstate * estate, PLpgSQL_stmt_block * block) (/build/src/pl/plpgsql/src/pl_exec.c:1639)
plpgsql.so!plpgsql_exec_function(PLpgSQL_function * func, FunctionCallInfo fcinfo, EState * simple_eval_estate, ResourceOwner simple_eval_resowner, ResourceOwner procedure_resowner, _Bool atomic) (/build/src/pl/plpgsql/src/pl_exec.c:628)
plpgsql.so!plpgsql_call_handler(FunctionCallInfo fcinfo) (/build/src/pl/plpgsql/src/pl_handler.c:277)
ExecInterpExpr(ExprState * state, ExprContext * econtext, _Bool * isnull) (/build/src/backend/executor/execExprInterp.c:734)
ExecInterpExprStillValid(ExprState * state, ExprContext * econtext, _Bool * isNull) (/build/src/backend/executor/execExprInterp.c:1870)
ExecEvalExprSwitchContext(ExprState * state, ExprContext * econtext, _Bool * isNull) (/build/src/include/executor/executor.h:355)
ExecProject(ProjectionInfo * projInfo) (/build/src/include/executor/executor.h:389)
ExecResult(PlanState * pstate) (/build/src/backend/executor/nodeResult.c:136)
ExecProcNodeFirst(PlanState * node) (/build/src/backend/executor/execProcnode.c:464)
ExecProcNode(PlanState * node) (/build/src/include/executor/executor.h:273)
ExecutePlan(EState * estate, PlanState * planstate, _Bool use_parallel_mode, CmdType operation, _Bool sendTuples, uint64 numberTuples, ScanDirection direction, DestReceiver * dest, _Bool execute_once) (/build/src/backend/executor/execMain.c:1678)
standard_ExecutorRun(QueryDesc * queryDesc, ScanDirection direction, uint64 count, _Bool execute_once) (/build/src/backend/executor/execMain.c:367)
ExecutorRun(QueryDesc * queryDesc, ScanDirection direction, uint64 count, _Bool execute_once) (/build/src/backend/executor/execMain.c:311)
PortalRunSelect(Portal portal, _Bool forward, long count, DestReceiver * dest) (/build/src/backend/tcop/pquery.c:924)
PortalRun(Portal portal, long count, _Bool isTopLevel, _Bool run_once, DestReceiver * dest, DestReceiver * altdest, QueryCompletion * qc) (/build/src/backend/tcop/pquery.c:768)
exec_simple_query(const char * query_string, int16 format) (/build/src/backend/tcop/postgres.c:1299)
PostgresMain(const char * dbname, const char * username) (/build/src/backend/tcop/postgres.c:4836)
BackendRun(Port * port) (/build/src/backend/postmaster/postmaster.c:4486)
BackendStartup(Port * port) (/build/src/backend/postmaster/postmaster.c:4206)
ServerLoop() (/build/src/backend/postmaster/postmaster.c:1794)
PostmasterMain(int argc, char ** argv) (/build/src/backend/postmaster/postmaster.c:1478)
main(int argc, char ** argv) (/build/src/backend/main/main.c:198)
```
