### PR TITLE
PG16-PG17: rename macros foreach_... to foreach_decl_...

### DIFF
--- a/columnar/configure
+++ b/columnar/configure
@@ -2802,7 +2802,7 @@ if test -z "$version_num"; then
   as_fn_error $? "Could not detect PostgreSQL version from pg_config." "$LINENO" 5
 fi
 
-if test "$version_num" != '13' -a "$version_num" != '14' -a "$version_num" != '15' -a "$version_num" != '16'; then
+if test "$version_num" != '13' -a "$version_num" != '14' -a "$version_num" != '15' -a "$version_num" != '16' -a "$version_num" != '17'; then
    as_fn_error $? "Citus is not compatible with the detected PostgreSQL version ${version_num}." "$LINENO" 5
 else
    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: building against PostgreSQL $version_num" >&5

--- a/columnar/configure
+++ b/columnar/configure
@@ -2802,7 +2802,7 @@ if test -z "$version_num"; then
   as_fn_error $? "Could not detect PostgreSQL version from pg_config." "$LINENO" 5
 fi
 
-if test "$version_num" != '13' -a "$version_num" != '14' -a "$version_num" != '15' -a "$version_num" != '16' -a "$version_num" != '17'; then
+if test "$version_num" != '13' -a "$version_num" != '14' -a "$version_num" != '15' -a "$version_num" != '16'; then
    as_fn_error $? "Citus is not compatible with the detected PostgreSQL version ${version_num}." "$LINENO" 5
 else
    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: building against PostgreSQL $version_num" >&5

--- a/columnar/src/backend/columnar/columnar_customscan.c
+++ b/columnar/src/backend/columnar/columnar_customscan.c
@@ -407,7 +407,7 @@ ColumnarGetRelationInfoHook(PlannerInfo *root, Oid relationObjectId,
 
 		/* disable index-only scan */
 		IndexOptInfo *indexOptInfo = NULL;
-		foreach_ptr(indexOptInfo, rel->indexlist)
+		foreach_decl_ptr(indexOptInfo, rel->indexlist)
 		{
 			memset(indexOptInfo->canreturn, false, indexOptInfo->ncolumns * sizeof(bool));
 		}
@@ -426,7 +426,7 @@ RemovePathsByPredicate(RelOptInfo *rel, PathPredicate removePathPredicate)
 	List *filteredPartialPathList = NIL;
 
 	Path *path = NULL;
-	foreach_ptr(path, rel->pathlist)
+	foreach_decl_ptr(path, rel->pathlist)
 	{
 		if (!removePathPredicate(path))
 		{
@@ -436,7 +436,7 @@ RemovePathsByPredicate(RelOptInfo *rel, PathPredicate removePathPredicate)
 
 	rel->pathlist = filteredPathList;
 
-	foreach_ptr(path, rel->partial_pathlist)
+	foreach_decl_ptr(path, rel->partial_pathlist)
 	{
 		if (!removePathPredicate(path))
 		{
@@ -483,7 +483,7 @@ static void
 CostColumnarPaths(PlannerInfo *root, RelOptInfo *rel, Oid relationId)
 {
 	Path *path = NULL;
-	foreach_ptr(path, rel->pathlist)
+	foreach_decl_ptr(path, rel->pathlist)
 	{
 		if (IsA(path, IndexPath))
 		{
@@ -833,7 +833,7 @@ ExtractPushdownClause(PlannerInfo *root, RelOptInfo *rel, Node *node)
 		List *pushdownableArgs = NIL;
 
 		Node *boolExprArg = NULL;
-		foreach_ptr(boolExprArg, boolExpr->args)
+		foreach_decl_ptr(boolExprArg, boolExpr->args)
 		{
 			Expr *pushdownableArg = ExtractPushdownClause(root, rel,
 														  (Node *) boolExprArg);
@@ -1656,7 +1656,7 @@ ColumnarPerStripeScanCost(RelOptInfo *rel, Oid relationId, int numberOfColumnsRe
 	uint32 maxColumnCount = 0;
 	uint64 totalStripeSize = 0;
 	StripeMetadata *stripeMetadata = NULL;
-	foreach_ptr(stripeMetadata, stripeList)
+	foreach_decl_ptr(stripeMetadata, stripeList)
 	{
 		totalStripeSize += stripeMetadata->dataLength;
 		maxColumnCount = Max(maxColumnCount, stripeMetadata->columnCount);
@@ -2443,7 +2443,7 @@ ColumnarScanNext(ColumnarScanState *columnarScanState)
 	{
 		VectorTupleTableSlot *vectorSlot = (VectorTupleTableSlot *) slot;
 		int attrIndex = -1;
-		foreach_int(attrIndex, columnarScanState->vectorization.attrNeededList)
+		foreach_decl_int(attrIndex, columnarScanState->vectorization.attrNeededList)
 		{
 			VectorColumn *column = (VectorColumn *) vectorSlot->tts.tts_values[attrIndex];
 			memset(column->isnull, true, COLUMNAR_VECTOR_COLUMN_SIZE);

--- a/columnar/src/backend/columnar/columnar_metadata.c
+++ b/columnar/src/backend/columnar/columnar_metadata.c
@@ -2603,7 +2603,7 @@ GetHighestUsedRowNumber(uint64 storageId)
 													  GetTransactionSnapshot(),
 													  ForwardScanDirection);
 	StripeMetadata *stripeMetadata = NULL;
-	foreach_ptr(stripeMetadata, stripeMetadataList)
+	foreach_decl_ptr(stripeMetadata, stripeMetadataList)
 	{
 		highestRowNumber = Max(highestRowNumber,
 							   StripeGetHighestRowNumber(stripeMetadata));

--- a/columnar/src/backend/columnar/columnar_reader.c
+++ b/columnar/src/backend/columnar/columnar_reader.c
@@ -1092,7 +1092,7 @@ ReadChunkGroupNextRow(ChunkGroupReadState *chunkGroupReadState, Datum *columnVal
 		}
 
 		int attno;
-		foreach_int(attno, chunkGroupReadState->projectedColumnList)
+		foreach_decl_int(attno, chunkGroupReadState->projectedColumnList)
 		{
 			const ChunkData *chunkGroupData = chunkGroupReadState->chunkGroupData;
 			const int rowIndex = chunkGroupReadState->currentRow;
@@ -1793,7 +1793,7 @@ ProjectedColumnMask(uint32 columnCount, List *projectedColumnList)
 	bool *projectedColumnMask = palloc0(columnCount * sizeof(bool));
 	int attno;
 
-	foreach_int(attno, projectedColumnList)
+	foreach_decl_int(attno, projectedColumnList)
 	{
 		/* attno is 1-indexed; projectedColumnMask is 0-indexed */
 		int columnIndex = attno - 1;
@@ -2222,7 +2222,7 @@ ReadChunkGroupNextVector(ChunkGroupReadState *chunkGroupReadState, Datum *column
 		}
 
 		int attno;
-		foreach_int(attno, chunkGroupReadState->projectedColumnList)
+		foreach_decl_int(attno, chunkGroupReadState->projectedColumnList)
 		{
 			const ChunkData *chunkGroupData = chunkGroupReadState->chunkGroupData;
 			const int rowIndex = chunkGroupReadState->currentRow;

--- a/columnar/src/backend/columnar/vectorization/columnar_vector_types.c
+++ b/columnar/src/backend/columnar/vectorization/columnar_vector_types.c
@@ -94,7 +94,7 @@ ExtractTupleFromVectorSlot(TupleTableSlot *out, VectorTupleTableSlot *vectorSlot
 						   int32 index, List *attrNeededList)
 {
 	int attno;
-	foreach_int(attno, attrNeededList)
+	foreach_decl_int(attno, attrNeededList)
 	{
 		if (!out->tts_tupleDescriptor->attrs[attno].attisdropped)
 		{

--- a/columnar/src/include/columnar/utils/listutils.h
+++ b/columnar/src/include/columnar/utils/listutils.h
@@ -40,7 +40,7 @@ typedef struct ListCellAndListWrapper
 } ListCellAndListWrapper;
 
 /*
- * foreach_ptr -
+ * foreach_decl_ptr -
  *	  a convenience macro which loops through a pointer list without needing a
  *	  ListCell, just a declared pointer variable to store the pointer of the
  *	  cell in.
@@ -54,7 +54,7 @@ typedef struct ListCellAndListWrapper
  *	  - || true is used to always enter the loop when cell is not null even if
  *	    var is NULL.
  */
-#define foreach_ptr(var, l) \
+#define foreach_decl_ptr(var, l) \
 	for (ListCell *(var ## CellDoNotUse) = list_head(l); \
 		 (var ## CellDoNotUse) != NULL && \
 		 (((var) = lfirst(var ## CellDoNotUse)) || true); \
@@ -62,12 +62,12 @@ typedef struct ListCellAndListWrapper
 
 
 /*
- * foreach_int -
+ * foreach_decl_int -
  *	  a convenience macro which loops through an int list without needing a
  *	  ListCell, just a declared int variable to store the int of the cell in.
- *	  For explanation of how it works see foreach_ptr.
+ *	  For explanation of how it works see foreach_decl_ptr.
  */
-#define foreach_int(var, l) \
+#define foreach_decl_int(var, l) \
 	for (ListCell *(var ## CellDoNotUse) = list_head(l); \
 		 (var ## CellDoNotUse) != NULL && \
 		 (((var) = lfirst_int(var ## CellDoNotUse)) || true); \
@@ -75,12 +75,12 @@ typedef struct ListCellAndListWrapper
 
 
 /*
- * foreach_oid -
+ * foreach_decl_oid -
  *	  a convenience macro which loops through an oid list without needing a
  *	  ListCell, just a declared Oid variable to store the oid of the cell in.
- *	  For explanation of how it works see foreach_ptr.
+ *	  For explanation of how it works see foreach_decl_ptr.
  */
-#define foreach_oid(var, l) \
+#define foreach_decl_oid(var, l) \
 	for (ListCell *(var ## CellDoNotUse) = list_head(l); \
 		 (var ## CellDoNotUse) != NULL && \
 		 (((var) = lfirst_oid(var ## CellDoNotUse)) || true); \
@@ -140,7 +140,7 @@ typedef struct ListCellAndListWrapper
 		 )
 
 /*
- * foreach_ptr_append -
+ * foreach_decl_ptr_append -
  *	  a convenience macro which loops through a pointer List and can append list
  *	  elements without needing a ListCell or and index variable, just a declared
  *	  pointer variable to store the iterated values.
@@ -163,13 +163,13 @@ typedef struct ListCellAndListWrapper
  *	    declared there.
  *	  - || true is used to always enter the loop even if var is NULL.
  */
-#define foreach_ptr_append(var, l) \
+#define foreach_decl_ptr_append(var, l) \
 	for (int var ## PositionDoNotUse = 0; \
 		 (var ## PositionDoNotUse) < list_length(l) && \
 		 (((var) = list_nth(l, var ## PositionDoNotUse)) || true); \
 		 var ## PositionDoNotUse ++)
 #else
-#define foreach_ptr_append(var, l) foreach_ptr(var, l)
+#define foreach_decl_ptr_append(var, l) foreach_decl_ptr(var, l)
 #endif
 
 static inline List*


### PR DESCRIPTION
It's a preparation PR for PG16 to migrate hydra to PG17. Can be merged in PG16 version

Rename foreach_... to foreach_decl_... to not conflict with PG17 macros

This PR can be merged without PG17, as only renames macros. Preparation step

