### PR TITLE
PG16-PG17: call RelationGetSmgr instead of custom code

### DIFF
--- a/columnar/src/backend/columnar/columnar_metadata.c
+++ b/columnar/src/backend/columnar/columnar_metadata.c
@@ -2556,16 +2556,7 @@ ColumnarStorageUpdateIfNeeded(Relation rel, bool isUpgrade)
 	 * RelationGetSmgr was added in 15, but only backported to 13.10 and 14.07
 	 * leaving other versions requiring something like this.
 	 */
-	if (unlikely(rel->rd_smgr == NULL))
-	{
-	#if PG_VERSION_NUM >= PG_VERSION_16
-		smgrsetowner(&(rel->rd_smgr), smgropen(rel->rd_locator, rel->rd_backend));
-	#else
-		smgrsetowner(&(rel->rd_smgr), smgropen(rel->rd_node, rel->rd_backend));
-	#endif
-	}
-
-	BlockNumber nblocks = smgrnblocks(rel->rd_smgr, MAIN_FORKNUM);
+	BlockNumber nblocks = smgrnblocks(RelationGetSmgr(rel), MAIN_FORKNUM);
 	if (nblocks < 2)
 	{
 		ColumnarStorageInit(rel->rd_smgr, ColumnarMetadataNewStorageId());

--- a/columnar/src/backend/columnar/columnar_metadata.c
+++ b/columnar/src/backend/columnar/columnar_metadata.c
@@ -2552,10 +2552,6 @@ ColumnarStorageUpdateIfNeeded(Relation rel, bool isUpgrade)
 		return;
 	}
 
-	/*
-	 * RelationGetSmgr was added in 15, but only backported to 13.10 and 14.07
-	 * leaving other versions requiring something like this.
-	 */
 	BlockNumber nblocks = smgrnblocks(RelationGetSmgr(rel), MAIN_FORKNUM);
 	if (nblocks < 2)
 	{

--- a/columnar/src/include/columnar/columnar_storage.h
+++ b/columnar/src/include/columnar/columnar_storage.h
@@ -61,4 +61,8 @@ extern void ColumnarStorageWrite(Relation rel, uint64 logicalOffset,
 								 char *data, uint32 amount);
 extern bool ColumnarStorageTruncate(Relation rel, uint64 newDataReservation);
 
+#if PG_VERSION_NUM < 140007
+inline SMgrRelation RelationGetSmgr(Relation rel);
+#endif
+
 #endif /* COLUMNAR_STORAGE_H */


### PR DESCRIPTION
It's a preparation PR for PG16 to migrate hydra to PG17.  Can be merged in PG16 version

This code should be changed in PG17, will be added one more `#elif`. 
```
	if (unlikely(rel->rd_smgr == NULL))
	BlockNumber nblocks = smgrnblocks(RelationGetSmgr(rel), MAIN_FORKNUM);
	{
	#if PG_VERSION_NUM >= PG_VERSION_16
		smgrsetowner(&(rel->rd_smgr), smgropen(rel->rd_locator, rel->rd_backend));
	#else
		smgrsetowner(&(rel->rd_smgr), smgropen(rel->rd_node, rel->rd_backend));
	#endif
	}
```

Will be changedto `smgrpin` See MR in Postgres 

```commit 21d9c3ee4ef74e2229341d39811c97f85071c90a
Author: Heikki Linnakangas <heikki.linnakangas@iki.fi>
Date:   Wed Jan 31 12:31:02 2024 +0200
Discussion: https://www.postgresql.org/message-id/CA%2BhUKGJ8NTvqLHz6dqbQnt2c8XCki4r2QvXjBQcXpVwxTY_pvA@mail.gmail.com
```

But this logic is included in the standard function `RelationGetSmgr`. Also see the same code in the Citus repository

https://github.com/citusdata/citus/blob/f7bead22d478ac3f407b1fb0f23739a289743bcc/src/backend/columnar/columnar_tableam.c#L1891